### PR TITLE
fix(aarch64-linux): use c_char for sqlite3_deserialize schema name for compatibility

### DIFF
--- a/src/rust/src/utils.rs
+++ b/src/rust/src/utils.rs
@@ -98,7 +98,7 @@ pub fn query_gallery_usage(db_bytes: &mut Vec<u8>) -> Result<u64, rusqlite::Erro
     unsafe {
         let db_ptr = rusqlite::ffi::sqlite3_deserialize(
             conn.handle(),
-            b"main\0".as_ptr() as *const i8,
+            b"main\0".as_ptr() as *const std::os::raw::c_char,
             db_bytes.as_mut_ptr(),
             db_bytes.len() as i64,
             db_bytes.len() as i64,


### PR DESCRIPTION
Build on aarch64 is failing with:
```bash
     |                      ---------------------------------- arguments to this function are incorrect
 100 |             conn.handle(),
 101 |             b"main\0".as_ptr() as *const i8,
     |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `*const u8`, found `*const i8`
     |
     = note: expected raw pointer `*const u8`
                found raw pointer `*const i8`
note: function defined here
    --> /build/source/build/cargo/rust_2a2b5/aarch64-unknown-linux-gnu/release/build/libsqlite3-sys-c773549f7dc001fe/out/bindgen.rs:2644:12
     |
2644 |     pub fn sqlite3_deserialize(
     |            ^^^^^^^^^^^^^^^^^^^

For more information about this error, try rustc --explain E0308.

warning: idescriptor_rust_codebase@0.1.0: Could not open /nix/store/sp1xlmzf32zi635v27qlbpdf2793dzlj-qtbase-6.11.0/lib/libQt6QuickControls2.prl file to read libraries to link: No such file or directory (os error 2)

warning: idescriptor_rust_codebase@0.1.0: Could not open /nix/store/sp1xlmzf32zi635v27qlbpdf2793dzlj-qtbase-6.11.0/lib/libQt6Qml.prl file to read libraries to link: No such file or directory (os error 2)

error: could not compile idescriptor_rust_codebase (lib) due to 1 previous error

make[2]: *** [CMakeFiles/_cargo-build_idescriptor_rust_codebase.dir/build.make:70: CMakeFiles/_cargo-build_idescriptor_rust_codebase] Error 101

make[1]: *** [CMakeFiles/Makefile2:292: CMakeFiles/_cargo-build_idescriptor_rust_codebase.dir/all] Error 2

make: *** [Makefile:156: all] Error 2
```

Passing build after fix applied: https://github.com/amadejkastelic/nixpkgs-review-gha/actions/runs/24994047283/job/73186391396