### PR TITLE
Add Qt Linguist i18n foundation with en/ja/zh_CN

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ else ()
 endif()
 
 find_package(PkgConfig REQUIRED)
-find_package(Qt6 REQUIRED COMPONENTS Widgets Multimedia MultimediaWidgets Network QuickControls2 SerialPort Positioning Location QuickWidgets) 
+find_package(Qt6 REQUIRED COMPONENTS Widgets Multimedia MultimediaWidgets Network QuickControls2 SerialPort Positioning Location QuickWidgets LinguistTools)
 # DBUS
 if (UNIX AND NOT APPLE)
     find_package(Qt6 REQUIRED COMPONENTS DBus)
@@ -371,6 +371,23 @@ endif()
 
 target_compile_definitions(iDescriptor PRIVATE
     APP_VERSION="${PROJECT_VERSION}"
+)
+
+# Translations
+# Compiled .qm files are embedded as Qt resources under the "/i18n" prefix
+# so the application can load them via QTranslator without external files.
+# To add a new language, append a translations/idescriptor_<locale>.ts entry
+# to TS_FILES and run the lupdate target to populate it.
+set(TS_FILES
+    translations/idescriptor_en.ts
+    translations/idescriptor_ja.ts
+    translations/idescriptor_zh_CN.ts
+)
+
+qt_add_translations(iDescriptor
+    TS_FILES ${TS_FILES}
+    RESOURCE_PREFIX "/i18n"
+    LUPDATE_OPTIONS -no-obsolete -locations relative
 )
 
 set_target_properties(iDescriptor PROPERTIES

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -384,11 +384,13 @@ set(TS_FILES
     translations/idescriptor_zh_CN.ts
 )
 
-qt_add_translations(iDescriptor
-    TS_FILES ${TS_FILES}
-    RESOURCE_PREFIX "/i18n"
-    LUPDATE_OPTIONS -no-obsolete -locations relative
-)
+if(QT_VERSION_MAJOR EQUAL 6)
+    qt_add_translations(iDescriptor
+        TS_FILES ${TS_FILES}
+        RESOURCE_PREFIX "/i18n"
+        LUPDATE_OPTIONS -no-obsolete -locations relative
+    )
+endif()
 
 set_target_properties(iDescriptor PROPERTIES
     ${BUNDLE_ID_OPTION}

--- a/docs/CONTRIBUTING_TRANSLATIONS.md
+++ b/docs/CONTRIBUTING_TRANSLATIONS.md
@@ -1,0 +1,74 @@
+# Contributing Translations
+
+iDescriptor uses Qt's translation system (Qt Linguist) to provide a localised
+user interface. Translations live in `translations/idescriptor_<locale>.ts`
+and are compiled into binary `.qm` files at build time and embedded as Qt
+resources under `:/i18n/`.
+
+## Adding a New Language
+
+1. Add the locale code to `TS_FILES` in `CMakeLists.txt`:
+
+   ```cmake
+   set(TS_FILES
+       translations/idescriptor_en.ts
+       translations/idescriptor_ja.ts
+       translations/idescriptor_zh_CN.ts
+       translations/idescriptor_<your_locale>.ts
+   )
+   ```
+
+2. Run `lupdate` to populate the new `.ts` file with all source strings:
+
+   ```bash
+   cmake --build build --target update_translations
+   ```
+
+   (Or `lupdate src -ts translations/idescriptor_<locale>.ts` directly.)
+3. Open the file in Qt Linguist (`linguist translations/idescriptor_<locale>.ts`)
+   and translate each entry.
+4. Mark each entry as "finished" in Linguist when satisfied with the translation.
+5. Build the project: the `.qm` is generated automatically and embedded
+   into the application binary.
+
+The new locale will appear in the **Settings -> Language** combo box on the
+next launch. Add a display label for the new code in
+`TranslationManager::displayName()` if you want a localised endonym instead
+of the raw locale code.
+
+## Improving an Existing Translation
+
+1. Open the relevant `.ts` file in Qt Linguist.
+2. Translations marked `unfinished` (yellow question mark in the GUI) need
+   review. Improve them and mark as finished.
+3. Submit a pull request. Touch only the `.ts` files for the language you
+   are improving.
+
+## Updating Translations After Source Changes
+
+When user-facing strings in the source code change, run:
+
+```bash
+cmake --build build --target update_translations
+```
+
+This synchronises every `.ts` file with the current set of `tr()` calls
+without losing existing translations. Re-translate any newly introduced
+entries in Linguist.
+
+## Style Guidelines
+
+- Preserve placeholders (`%1`, `%2`, `%n`) as-is in your translation.
+- Preserve mnemonics (`&` accelerators); convention varies by locale --
+  Japanese uses `(&X)` at the end, and Simplified Chinese follows the same
+  convention.
+- Do not translate proper names (iDescriptor, AirPlay, Mica, Wi-Fi).
+- Match the conventions of the OS your locale targets (Apple HIG, Microsoft
+  Style Guide, GNOME HIG, etc.).
+- Keep translations concise; UI elements often have limited width.
+
+## Reporting Translation Issues
+
+Open an issue at <https://github.com/iDescriptor/iDescriptor/issues> with
+the language, the source string, the current translation, and the suggested
+improvement.

--- a/src/i18n_helper.h
+++ b/src/i18n_helper.h
@@ -1,0 +1,52 @@
+/*
+ * iDescriptor: A free and open-source idevice management tool.
+ *
+ * Copyright (C) 2025 Uncore <https://github.com/uncor3>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef IDESCRIPTOR_I18N_HELPER_H
+#define IDESCRIPTOR_I18N_HELPER_H
+
+#include <QCoreApplication>
+#include <QString>
+
+// Thin wrappers around QCoreApplication::translate() so that translation
+// lookups can be performed by code that does not have access to a QObject
+// subclass (notably future Rust modules linked through cxx-qt). The
+// implementation simply forwards to Qt's translation infrastructure, which
+// keeps the .ts/.qm pipeline as the single source of truth.
+
+namespace idescriptor::i18n
+{
+
+inline QString tr(const char *context, const char *sourceText)
+{
+    return QCoreApplication::translate(context, sourceText);
+}
+
+inline QString tr(const char *context, const char *sourceText,
+                  const char *disambiguation, int n = -1)
+{
+    return QCoreApplication::translate(context, sourceText, disambiguation, n);
+}
+
+} // namespace idescriptor::i18n
+
+// Future C ABI wrappers for cxx-qt / Rust integration are intentionally
+// omitted in this initial PR; the namespace above is sufficient for C++
+// callers and provides a stable seam to extend.
+
+#endif // IDESCRIPTOR_I18N_HELPER_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,6 +20,7 @@
 #include "iDescriptor.h"
 #include "mainwindow.h"
 #include "settingsmanager.h"
+#include "translationmanager.h"
 #include <QApplication>
 #include <QDebug>
 #include <QDir>
@@ -38,11 +39,15 @@ int main(int argc, char *argv[])
     QCoreApplication::setOrganizationName("iDescriptor");
     QCoreApplication::setApplicationName("iDescriptor");
     QCoreApplication::setApplicationVersion(APP_VERSION);
+    TranslationManager::sharedInstance()->initFromSettings();
     if (a.arguments().contains("--reset-settings")) {
         SettingsManager::sharedInstance()->clear();
-        QMessageBox::information(nullptr, "Settings Reset",
-                                 "All application settings have been reset to "
-                                 "their default values.");
+        QMessageBox::information(
+            nullptr,
+            QCoreApplication::translate("main", "Settings Reset"),
+            QCoreApplication::translate(
+                "main",
+                "All application settings have been reset to their default values."));
     }
 #ifdef WIN32
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -426,17 +426,36 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent)
 
 void MainWindow::createMenus()
 {
-#ifdef Q_OS_MAC
-    QMenu *actionsMenu = menuBar()->addMenu("&Actions");
+    m_helpMenu = menuBar()->addMenu(QString());
 
-    QAction *aboutAct = new QAction("&About iDescriptor", this);
-    connect(aboutAct, &QAction::triggered, this, [this]() {
-        QMessageBox::about(this, "iDescriptor",
-                           "A free, open-source, and cross-platform "
-                           "iDevice management tool.");
-    });
-    actionsMenu->addAction(aboutAct);
-#endif
+    m_aboutAction = new QAction(this);
+    // setMenuRole(AboutRole) ensures macOS moves the action to the
+    // application menu automatically while other platforms keep it under
+    // the Help menu.
+    m_aboutAction->setMenuRole(QAction::AboutRole);
+    connect(m_aboutAction, &QAction::triggered, this, &MainWindow::showAbout);
+    m_helpMenu->addAction(m_aboutAction);
+
+    retranslateMenus();
+}
+
+void MainWindow::retranslateMenus()
+{
+    if (m_helpMenu) {
+        m_helpMenu->setTitle(tr("&Help"));
+    }
+    if (m_aboutAction) {
+        m_aboutAction->setText(
+            tr("&About %1").arg(qApp->applicationName()));
+    }
+}
+
+void MainWindow::showAbout()
+{
+    QMessageBox::about(this,
+                       tr("About %1").arg(qApp->applicationName()),
+                       tr("A free, open-source, and cross-platform "
+                          "iDevice management tool."));
 }
 
 void MainWindow::updateNoDevicesConnected()

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -151,34 +151,36 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent)
     connect(m_deviceManager, &DeviceManagerWidget::updateNoDevicesConnected,
             this, &MainWindow::updateNoDevicesConnected);
 
-    m_ZTabWidget->addTab(m_mainStackedWidget, "iDevice");
-    auto *appsWidgetTab =
-        m_ZTabWidget->addTab(AppsWidget::sharedInstance(), "Apps");
-    m_ZTabWidget->addTab(ToolboxWidget::sharedInstance(), "Toolbox");
+    m_iDeviceTab = m_ZTabWidget->addTab(m_mainStackedWidget, tr("iDevice"));
+    m_appsTab = m_ZTabWidget->addTab(AppsWidget::sharedInstance(), tr("Apps"));
+    m_toolboxTab =
+        m_ZTabWidget->addTab(ToolboxWidget::sharedInstance(), tr("Toolbox"));
     auto *jailbrokenWidget = new JailbrokenWidget(this);
-    m_ZTabWidget->addTab(jailbrokenWidget, "Jailbroken");
+    m_jailbrokenTab = m_ZTabWidget->addTab(jailbrokenWidget, tr("Jailbroken"));
     m_ZTabWidget->finalizeStyles();
 
     connect(
-        appsWidgetTab, &ZTab::clicked, this,
+        m_appsTab, &ZTab::clicked, this,
         [this](int index) { AppsWidget::sharedInstance()->init(); },
         Qt::SingleShotConnection);
 
     // settings button
-    ZIconWidget *settingsButton = new ZIconWidget(
-        QIcon(":/resources/icons/MingcuteSettings7Line.png"), "Settings");
-    settingsButton->setCursor(Qt::PointingHandCursor);
-    connect(settingsButton, &ZIconWidget::clicked, this, [this]() {
+    m_settingsButton = new ZIconWidget(
+        QIcon(":/resources/icons/MingcuteSettings7Line.png"), tr("Settings"));
+    m_settingsButton->setCursor(Qt::PointingHandCursor);
+    connect(m_settingsButton, &ZIconWidget::clicked, this, [this]() {
         SettingsManager::sharedInstance()->showSettingsDialog();
     });
 
-    ZIconWidget *githubButton = new ZIconWidget(
-        QIcon(":/resources/icons/MdiGithub.png"), "iDescriptor on GitHub");
-    githubButton->setCursor(Qt::PointingHandCursor);
-    connect(githubButton, &ZIconWidget::clicked, this,
+    m_githubButton =
+        new ZIconWidget(QIcon(":/resources/icons/MdiGithub.png"),
+                        tr("%1 on GitHub").arg(qApp->applicationName()));
+    m_githubButton->setCursor(Qt::PointingHandCursor);
+    connect(m_githubButton, &ZIconWidget::clicked, this,
             []() { QDesktopServices::openUrl(QUrl(REPO_URL)); });
 
-    m_connectedDeviceCountLabel = new QLabel("iDescriptor: no devices");
+    m_connectedDeviceCountLabel = new QLabel(
+        tr("%1: no devices").arg(qApp->applicationName()));
     m_connectedDeviceCountLabel->setContentsMargins(0, 0, 0, 0);
     m_connectedDeviceCountLabel->setStyleSheet(
         "QLabel:hover { background-color : #13131319; }");
@@ -196,30 +198,30 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent)
 
     statusLayout->addWidget(statusBalloon->getButton());
 
-    ZIconWidget *welcomeMenuSwitch = new ZIconWidget(
+    m_welcomeMenuSwitch = new ZIconWidget(
         QIcon(":/resources/icons/LetsIconsHorizontalDownLeftMainLight.png"),
-        "Switch to Welcome Menu");
-    connect(welcomeMenuSwitch, &ZIconWidget::clicked, this,
-            [this, welcomeMenuSwitch]() {
-                if (m_mainStackedWidget->currentIndex() != 0) {
-                    welcomeMenuSwitch->setToolTip(
-                        "Switch to Connected Devices");
-                    return showWelcomeTab();
-                }
-                welcomeMenuSwitch->setToolTip("Switch to Welcome Menu");
-                showConnectedDevicesTab();
-            });
+        tr("Switch to Welcome Menu"));
+    connect(m_welcomeMenuSwitch, &ZIconWidget::clicked, this, [this]() {
+        if (m_mainStackedWidget->currentIndex() != 0) {
+            m_welcomeTabActive = true;
+            m_welcomeMenuSwitch->setToolTip(tr("Switch to Connected Devices"));
+            return showWelcomeTab();
+        }
+        m_welcomeTabActive = false;
+        m_welcomeMenuSwitch->setToolTip(tr("Switch to Welcome Menu"));
+        showConnectedDevicesTab();
+    });
 
     connect(m_ZTabWidget, &ZTabWidget::currentChanged, this,
-            [welcomeMenuSwitch](int index) {
+            [this](int index) {
                 if (index != 0) {
-                    return welcomeMenuSwitch->hide();
+                    return m_welcomeMenuSwitch->hide();
                 }
 
-                welcomeMenuSwitch->show();
+                m_welcomeMenuSwitch->show();
             });
 
-    statusLayout->addWidget(welcomeMenuSwitch);
+    statusLayout->addWidget(m_welcomeMenuSwitch);
     statusLayout->addStretch(1);
 
     QLabel *appVersionLabel = new QLabel(QString("v%1").arg(APP_VERSION));
@@ -243,9 +245,11 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent)
                 [this, p, path, statusLayout]() {
                     bool ok = iFuseManager::linuxUnmount(path);
                     if (!ok) {
-                        QMessageBox::warning(nullptr, "Unmount Failed",
-                                             "Failed to unmount iFuse at " +
-                                                 path + ". Please try again.");
+                        QMessageBox::warning(
+                            nullptr, tr("Unmount Failed"),
+                            tr("Failed to unmount iFuse at %1. Please "
+                               "try again.")
+                                .arg(path));
                         return;
                     }
                     statusLayout->removeWidget(p);
@@ -292,11 +296,13 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent)
             !isPortable,
             isPortable,
             !isPortable,
-            isPortable ? "New portable version downloaded, app location will "
-                         "be shown after this message"
-                       : "The application will now quit to install the update.",
-            isPortable ? "New portable version downloaded"
-                       : "Do you want to install the downloaded update now?",
+            isPortable
+                ? tr("New portable version downloaded, app location will "
+                     "be shown after this message")
+                : tr("The application will now quit to install the update."),
+            isPortable
+                ? tr("New portable version downloaded")
+                : tr("Do you want to install the downloaded update now?"),
         };
         break;
         // todo: adjust for pkg managers
@@ -305,10 +311,11 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent)
             true,
             false,
             true,
-            "The application will now quit and open .dmg file downloaded to "
-            "\"Downloads\" from there you can drag it to Applications to "
-            "install.",
-            "Update downloaded would you like to quit and install the update?",
+            tr("The application will now quit and open .dmg file downloaded "
+               "to \"Downloads\" from there you can drag it to Applications "
+               "to install."),
+            tr("Update downloaded would you like to quit and install the "
+               "update?"),
         };
         break;
     case Platform::Linux:
@@ -320,13 +327,12 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent)
             true,
             false,
             true,
-            "AppImages we ship are not updateable. New version is downloaded "
-            "to "
-            "\"Downloads\". You can start using the new version by launching "
-            "it "
-            "from there. You can delete this AppImage version if you like.",
-            "Update downloaded would you like to quit and open the new "
-            "version?",
+            tr("AppImages we ship are not updateable. New version is "
+               "downloaded to \"Downloads\". You can start using the new "
+               "version by launching it from there. You can delete this "
+               "AppImage version if you like."),
+            tr("Update downloaded would you like to quit and open the new "
+               "version?"),
         };
         break;
     default:
@@ -340,10 +346,9 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent)
                              packageManagerManaged, skipPrerelease, this);
 #if defined(PACKAGE_MANAGER_MANAGED) && defined(__linux__)
     m_updater->setPackageManagerManagedMessage(
-        QString(
-            "You seem to have installed iDescriptor using a package manager. "
-            "Please use %1 to update it.")
-            .arg(PACKAGE_MANAGER_HINT));
+        tr("You seem to have installed %1 using a package manager. "
+           "Please use %2 to update it.")
+            .arg(qApp->applicationName(), PACKAGE_MANAGER_HINT));
 #endif
 
     QString lastAppVersion = SettingsManager::sharedInstance()->appVersion();
@@ -450,6 +455,68 @@ void MainWindow::retranslateMenus()
     }
 }
 
+void MainWindow::retranslateTabs()
+{
+    if (m_iDeviceTab) {
+        m_iDeviceTab->setText(tr("iDevice"));
+    }
+    if (m_appsTab) {
+        m_appsTab->setText(tr("Apps"));
+    }
+    if (m_toolboxTab) {
+        m_toolboxTab->setText(tr("Toolbox"));
+    }
+    if (m_jailbrokenTab) {
+        m_jailbrokenTab->setText(tr("Jailbroken"));
+    }
+}
+
+void MainWindow::retranslateStatusBar()
+{
+    if (m_settingsButton) {
+        m_settingsButton->setToolTip(tr("Settings"));
+    }
+    if (m_githubButton) {
+        m_githubButton->setToolTip(
+            tr("%1 on GitHub").arg(qApp->applicationName()));
+    }
+    if (m_welcomeMenuSwitch) {
+        // The tooltip describes the action the user can perform next:
+        // when the welcome page is visible, the next action is to jump
+        // to the connected-devices view, and vice versa.
+        m_welcomeMenuSwitch->setToolTip(
+            m_welcomeTabActive ? tr("Switch to Connected Devices")
+                               : tr("Switch to Welcome Menu"));
+    }
+    if (m_connectedDeviceCountLabel) {
+        if (m_connectedDeviceCount == 0) {
+            m_connectedDeviceCountLabel->setText(
+                tr("%1: no devices").arg(qApp->applicationName()));
+        } else {
+            // %n triggers Qt's plural handling so translators can provide
+            // singular/plural forms for "device(s) connected".
+            m_connectedDeviceCountLabel->setText(
+                tr("%1: %n device(s) connected", "", m_connectedDeviceCount)
+                    .arg(qApp->applicationName()));
+        }
+    }
+}
+
+void MainWindow::retranslateUi()
+{
+    retranslateMenus();
+    retranslateTabs();
+    retranslateStatusBar();
+}
+
+void MainWindow::changeEvent(QEvent *event)
+{
+    if (event->type() == QEvent::LanguageChange) {
+        retranslateUi();
+    }
+    QMainWindow::changeEvent(event);
+}
+
 void MainWindow::showAbout()
 {
     QMessageBox::about(this,
@@ -463,14 +530,13 @@ void MainWindow::updateNoDevicesConnected()
     qDebug() << "No devices connected? "
              << AppContext::sharedInstance()->noDevicesConnected();
     if (AppContext::sharedInstance()->noDevicesConnected()) {
-
-        m_connectedDeviceCountLabel->setText("iDescriptor: no devices");
+        m_connectedDeviceCount = 0;
+        retranslateStatusBar();
         return m_mainStackedWidget->setCurrentIndex(0); // Show Welcome page
     }
-    int deviceCount = AppContext::sharedInstance()->getConnectedDeviceCount();
-    m_connectedDeviceCountLabel->setText(
-        "iDescriptor: " + QString::number(deviceCount) +
-        (deviceCount == 1 ? " device" : " devices") + " connected");
+    m_connectedDeviceCount =
+        AppContext::sharedInstance()->getConnectedDeviceCount();
+    retranslateStatusBar();
     m_mainStackedWidget->setCurrentIndex(1); // Show device list page
 }
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -30,6 +30,7 @@
 #include <QApplication>
 #include <QDateTime>
 #include <QDesktopServices>
+#include <QEvent>
 #include <QHBoxLayout>
 #include <QLabel>
 #include <QMainWindow>
@@ -65,7 +66,10 @@ private slots:
 
 private:
     void createMenus();
+    void retranslateUi();
     void retranslateMenus();
+    void retranslateTabs();
+    void retranslateStatusBar();
 
     ZTabWidget *m_ZTabWidget;
     DeviceManagerWidget *m_deviceManager;
@@ -82,7 +86,23 @@ private:
     QMenu *m_helpMenu = nullptr;
     QAction *m_aboutAction = nullptr;
 
+    ZTab *m_iDeviceTab = nullptr;
+    ZTab *m_appsTab = nullptr;
+    ZTab *m_toolboxTab = nullptr;
+    ZTab *m_jailbrokenTab = nullptr;
+
+    ZIconWidget *m_settingsButton = nullptr;
+    ZIconWidget *m_githubButton = nullptr;
+    ZIconWidget *m_welcomeMenuSwitch = nullptr;
+
+    int m_connectedDeviceCount = 0;
+    // Tracks the welcome-menu-switch tooltip phrasing. Initialized to
+    // false to mirror the historical initial tooltip value, which the
+    // click handler keeps in sync from there on.
+    bool m_welcomeTabActive = false;
+
 protected:
     void closeEvent(QCloseEvent *event) override;
+    void changeEvent(QEvent *event) override;
 };
 #endif // MAINWINDOW_H

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -26,6 +26,7 @@
 #include "iDescriptor.h"
 #include "iomanagerclient.h"
 #include "ztabwidget.h"
+#include <QAction>
 #include <QApplication>
 #include <QDateTime>
 #include <QDesktopServices>
@@ -59,8 +60,12 @@ public:
 public slots:
     void updateNoDevicesConnected();
 
+private slots:
+    void showAbout();
+
 private:
     void createMenus();
+    void retranslateMenus();
 
     ZTabWidget *m_ZTabWidget;
     DeviceManagerWidget *m_deviceManager;
@@ -73,6 +78,9 @@ private:
     QWidget *m_titleBar;
     QWidget *m_contentArea;
     QHBoxLayout *m_titleBarLayout;
+
+    QMenu *m_helpMenu = nullptr;
+    QAction *m_aboutAction = nullptr;
 
 protected:
     void closeEvent(QCloseEvent *event) override;

--- a/src/settingsmanager.cpp
+++ b/src/settingsmanager.cpp
@@ -45,7 +45,7 @@ void SettingsManager::showSettingsDialog()
     }
 
     m_dialog = new SettingsWidget();
-    m_dialog->setWindowTitle("Settings - iDescriptor");
+    m_dialog->setWindowTitle(tr("Settings - iDescriptor"));
     m_dialog->setModal(true);
     m_dialog->setAttribute(Qt::WA_DeleteOnClose);
     connect(m_dialog, &QObject::destroyed, [this]() { m_dialog = nullptr; });
@@ -185,6 +185,21 @@ void SettingsManager::setTheme(const QString &theme)
     m_settings->sync();
 }
 
+QString SettingsManager::language() const
+{
+    return m_settings->value("language", QString()).toString();
+}
+
+void SettingsManager::setLanguage(const QString &code)
+{
+    if (language() == code) {
+        return;
+    }
+    m_settings->setValue("language", code);
+    m_settings->sync();
+    emit languageChanged(code);
+}
+
 int SettingsManager::connectionTimeout() const
 {
     return m_settings->value("connectionTimeout", 30).toInt();
@@ -290,6 +305,7 @@ void SettingsManager::resetToDefaults()
     setWinBackdropType(ACRYLIC);
     setDisableMica(false);
 #endif
+    setLanguage(QString());
 }
 
 void SettingsManager::saveFavoritePlace(const QString &path,

--- a/src/settingsmanager.h
+++ b/src/settingsmanager.h
@@ -47,7 +47,8 @@ public:
         SwitchToNewDevice,
         UnmountiFuseOnExit,
         Theme,
-        ConnectionTimeout
+        ConnectionTimeout,
+        Language,
     };
     static QString homePath();
     QString devdiskimgpath() const;
@@ -92,6 +93,9 @@ public:
 
     QString theme() const;
     void setTheme(const QString &theme);
+
+    QString language() const;
+    void setLanguage(const QString &code);
 
     int connectionTimeout() const;
     void setConnectionTimeout(int seconds);
@@ -159,6 +163,7 @@ public:
 signals:
     void favoritePlacesChanged();
     void recentLocationsChanged();
+    void languageChanged(const QString &code);
 
 private:
     QDialog *m_dialog;

--- a/src/settingswidget.cpp
+++ b/src/settingswidget.cpp
@@ -20,9 +20,11 @@
 #include "settingswidget.h"
 #include "mainwindow.h"
 #include "settingsmanager.h"
+#include "translationmanager.h"
 #include <QCheckBox>
 #include <QComboBox>
 #include <QDialog>
+#include <QEvent>
 #include <QFileDialog>
 #include <QFrame>
 #include <QGroupBox>
@@ -42,13 +44,23 @@
 #include <QOperatingSystemVersion>
 #endif
 
+// Locale-independent identifiers used as combo userData. They survive
+// language changes and are also what gets persisted via SettingsManager,
+// so the saved value remains meaningful across locales.
+#define IDESC_THEME_SYSTEM_DEFAULT "System Default"
+#ifdef WIN32
+#define IDESC_BACKDROP_AUTO "Auto"
+#endif
+
 SettingsWidget::SettingsWidget(QWidget *parent) : QDialog{parent}
 {
 #ifdef WIN32
+    m_backDropTypeLabel = nullptr;
     m_backDropTypeCombo = nullptr;
     m_disableMicaCheckBox = nullptr;
 #endif
     setupUI();
+    retranslateUi();
     loadSettings();
     connectSignals();
     // due to scrollbar add 10px on windows
@@ -72,28 +84,27 @@ void SettingsWidget::setupUI()
     scrollLayout->setContentsMargins(10, 10, 10, 10);
 
     // === GENERAL SETTINGS ===
-    auto *generalGroup = new QGroupBox("General");
-    auto *generalLayout = new QVBoxLayout(generalGroup);
+    m_generalGroup = new QGroupBox();
+    auto *generalLayout = new QVBoxLayout(m_generalGroup);
 
     // Download path
     auto *downloadLayout = new QHBoxLayout();
-    downloadLayout->addWidget(new QLabel("Download Path:"));
+    m_downloadPathLabel = new QLabel();
+    downloadLayout->addWidget(m_downloadPathLabel);
     m_downloadPathEdit = new QLineEdit();
     m_downloadPathEdit->setReadOnly(true);
     m_downloadPathEdit->setMaximumWidth(300);
     downloadLayout->addWidget(m_downloadPathEdit);
-    auto *browseButton = new QPushButton("Browse...");
-    downloadLayout->addWidget(browseButton);
+    m_browseButton = new QPushButton();
+    downloadLayout->addWidget(m_browseButton);
     generalLayout->addLayout(downloadLayout);
 
     // Wireless file server port
     auto *portLayout = new QHBoxLayout();
-    portLayout->addWidget(new QLabel("Wireless File Server Port:"));
+    m_wirelessFileServerPortLabel = new QLabel();
+    portLayout->addWidget(m_wirelessFileServerPortLabel);
     m_wirelessFileServerPort = new QSpinBox();
     m_wirelessFileServerPort->setRange(1024, 65535);
-    m_wirelessFileServerPort->setToolTip(
-        "The starting port for the wireless file server. If this port is "
-        "unavailable, it will try the next 10 ports.");
     portLayout->addWidget(m_wirelessFileServerPort);
     portLayout->addStretch();
     generalLayout->addLayout(portLayout);
@@ -101,152 +112,158 @@ void SettingsWidget::setupUI()
     // Unmount iFuse drives on exit (not implemented on macOS)
     // TODO: Implement
 #ifndef __APPLE__
-    m_unmount_iFuseDrives = new QCheckBox("Unmount iFuse drives on exit");
+    m_unmount_iFuseDrives = new QCheckBox();
     generalLayout->addWidget(m_unmount_iFuseDrives);
 #endif
 
-    connect(browseButton, &QPushButton::clicked, this,
+    connect(m_browseButton, &QPushButton::clicked, this,
             &SettingsWidget::onBrowseButtonClicked);
 
     // Auto-check for updates
-    m_autoUpdateCheck = new QCheckBox("Automatically check for updates");
+    m_autoUpdateCheck = new QCheckBox();
     generalLayout->addWidget(m_autoUpdateCheck);
 
-    m_autoEnableWifiConnections =
-        new QCheckBox("Automatically enable Wi-Fi connections");
+    m_autoEnableWifiConnections = new QCheckBox();
     generalLayout->addWidget(m_autoEnableWifiConnections);
 
     // Theme selection
     auto *themeLayout = new QHBoxLayout();
-    themeLayout->addWidget(new QLabel("Theme:"));
+    m_themeLabel = new QLabel();
+    themeLayout->addWidget(m_themeLabel);
     m_themeCombo = new QComboBox();
 
     /* FIXME: Theme control needs to be implemented */
-    m_themeCombo->addItems({"System Default"});
-    // m_themeCombo->addItems({"System Default", "Light", "Dark"});
+    // userData carries the locale-independent identifier persisted by
+    // SettingsManager. Display text is localised in retranslateUi().
+    m_themeCombo->addItem(QString(), QStringLiteral(IDESC_THEME_SYSTEM_DEFAULT));
 
     themeLayout->addWidget(m_themeCombo);
     themeLayout->addStretch();
+    generalLayout->addLayout(themeLayout);
+
+    // Language selection
+    auto *languageLayout = new QHBoxLayout();
+    m_languageLabel = new QLabel();
+    languageLayout->addWidget(m_languageLabel);
+    m_languageCombo = new QComboBox();
+    for (const QString &code : TranslationManager::availableLocaleCodes()) {
+        // Display name is filled in retranslateUi(); userData is the locale
+        // code, which is what we persist and look up by.
+        m_languageCombo->addItem(QString(), code);
+    }
+    languageLayout->addWidget(m_languageCombo);
+    languageLayout->addStretch();
+    generalLayout->addLayout(languageLayout);
 
 #ifdef WIN32
     QOperatingSystemVersion osVersion = QOperatingSystemVersion::current();
     if (osVersion >= QOperatingSystemVersion::Windows11) {
         auto *backDropTypeLayout = new QHBoxLayout();
-        backDropTypeLayout->addWidget(new QLabel("Backdrop Type:"));
+        m_backDropTypeLabel = new QLabel();
+        backDropTypeLayout->addWidget(m_backDropTypeLabel);
         m_backDropTypeCombo = new QComboBox();
 
-        // "Auto" => no userData => means "no override"
-        m_backDropTypeCombo->addItem("Auto");
-        m_backDropTypeCombo->addItem("Mica", static_cast<int>(MICA));
-        m_backDropTypeCombo->addItem("Mica Alt", static_cast<int>(MICA_ALT));
-        m_backDropTypeCombo->addItem("Acrylic", static_cast<int>(ACRYLIC));
+        // "Auto" => no override; other entries carry the WIN_BACKDROP int.
+        m_backDropTypeCombo->addItem(QString(),
+                                     QStringLiteral(IDESC_BACKDROP_AUTO));
+        m_backDropTypeCombo->addItem(QString(), static_cast<int>(MICA));
+        m_backDropTypeCombo->addItem(QString(), static_cast<int>(MICA_ALT));
+        m_backDropTypeCombo->addItem(QString(), static_cast<int>(ACRYLIC));
 
         backDropTypeLayout->addWidget(m_backDropTypeCombo);
         backDropTypeLayout->addStretch();
 
         generalLayout->addLayout(backDropTypeLayout);
 
-        m_disableMicaCheckBox =
-            new QCheckBox("Disable Mica effects (also disables WinUI styles)");
+        m_disableMicaCheckBox = new QCheckBox();
         generalLayout->addWidget(m_disableMicaCheckBox);
     }
 #endif
 
-    scrollLayout->addWidget(generalGroup);
+    scrollLayout->addWidget(m_generalGroup);
 
     // === DEVICE CONNECTION SETTINGS ===
-    auto *deviceGroup = new QGroupBox("Device Connection");
-    auto *deviceLayout = new QVBoxLayout(deviceGroup);
+    m_deviceGroup = new QGroupBox();
+    auto *deviceLayout = new QVBoxLayout(m_deviceGroup);
 
-    m_autoRaiseWindow =
-        new QCheckBox("Auto-raise main window on device connection");
+    m_autoRaiseWindow = new QCheckBox();
     deviceLayout->addWidget(m_autoRaiseWindow);
 
-    m_switchToNewDevice = new QCheckBox("Switch to newly connected device");
+    m_switchToNewDevice = new QCheckBox();
     deviceLayout->addWidget(m_switchToNewDevice);
 
-    m_autoConnectWirelessDevices =
-        new QCheckBox("Automatically connect to wireless devices");
+    m_autoConnectWirelessDevices = new QCheckBox();
     deviceLayout->addWidget(m_autoConnectWirelessDevices);
 
     // Connection timeout
     auto *timeoutLayout = new QHBoxLayout();
-    timeoutLayout->addWidget(new QLabel("Connection Timeout:"));
+    m_connectionTimeoutLabel = new QLabel();
+    timeoutLayout->addWidget(m_connectionTimeoutLabel);
     m_connectionTimeout = new QSpinBox();
     m_connectionTimeout->setRange(5, 60);
-    m_connectionTimeout->setSuffix(" seconds");
     timeoutLayout->addWidget(m_connectionTimeout);
     timeoutLayout->addStretch();
     deviceLayout->addLayout(timeoutLayout);
 
-    scrollLayout->addWidget(deviceGroup);
+    scrollLayout->addWidget(m_deviceGroup);
 
     // === SECURITY SETTINGS ===
-    auto *securityGroup = new QGroupBox("Security");
-    auto *securityLayout = new QVBoxLayout(securityGroup);
+    m_securityGroup = new QGroupBox();
+    auto *securityLayout = new QVBoxLayout(m_securityGroup);
 
-    m_useUnsecureBackend =
-        new QCheckBox("Use unsecure backend for app store (ipatool)");
-    m_useUnsecureBackend->setToolTip(
-        "Enabling this may put your Apple account at risk but you don't have "
-        "to deal with Apple keychain.");
+    m_useUnsecureBackend = new QCheckBox();
     securityLayout->addWidget(m_useUnsecureBackend);
-    scrollLayout->addWidget(securityGroup);
+    scrollLayout->addWidget(m_securityGroup);
 
     // === JAILBROKEN SETTINGS ===
-    auto *jailbrokenGroup = new QGroupBox("Jailbroken");
-    auto *jailbrokenLayout = new QVBoxLayout(jailbrokenGroup);
+    m_jailbrokenGroup = new QGroupBox();
+    auto *jailbrokenLayout = new QVBoxLayout(m_jailbrokenGroup);
 
     // Default jailbroken root password
     auto *passwordLayout = new QHBoxLayout();
-    passwordLayout->addWidget(new QLabel("Default Jailbroken Root Password:"));
+    m_defaultJailbrokenRootPasswordLabel = new QLabel();
+    passwordLayout->addWidget(m_defaultJailbrokenRootPasswordLabel);
     m_defaultJailbrokenRootPassword = new QLineEdit();
     m_defaultJailbrokenRootPassword->setEchoMode(QLineEdit::PasswordEchoOnEdit);
     m_defaultJailbrokenRootPassword->setMaximumWidth(200);
-    m_defaultJailbrokenRootPassword->setToolTip(
-        "Default password used for SSH root authentication on jailbroken "
-        "devices: Default is 'alpine'.");
     passwordLayout->addWidget(m_defaultJailbrokenRootPassword);
     passwordLayout->addStretch();
     jailbrokenLayout->addLayout(passwordLayout);
 
-    scrollLayout->addWidget(jailbrokenGroup);
+    scrollLayout->addWidget(m_jailbrokenGroup);
 
     // === AirPlay SETTINGS ===
-    auto *airplayGroup = new QGroupBox("AirPlay");
-    auto *airplayLayout = new QVBoxLayout(airplayGroup);
+    m_airplayGroup = new QGroupBox();
+    auto *airplayLayout = new QVBoxLayout(m_airplayGroup);
 
     auto *fpsLayout = new QHBoxLayout();
 
-    auto *fpsLabel = new QLabel("Fps:");
+    m_fpsLabel = new QLabel();
     m_fpsComboBox = new QComboBox();
+    // The FPS values are numeric and locale-independent; no tr() needed.
     m_fpsComboBox->addItems({"24", "30", "60", "120"});
-    m_fpsComboBox->setToolTip(
-        "Set the fps for AirPlay. Go with 30 fps if have an older device.");
 
-    fpsLayout->addWidget(fpsLabel);
+    fpsLayout->addWidget(m_fpsLabel);
     fpsLayout->addWidget(m_fpsComboBox);
     fpsLayout->addStretch();
     airplayLayout->addLayout(fpsLayout);
 
-    m_noHoldCheckbox = new QCheckBox("Allow New Connections to Take Over");
+    m_noHoldCheckbox = new QCheckBox();
     airplayLayout->addWidget(m_noHoldCheckbox);
 
 #ifdef __linux__
-    m_useLegacyPortsCheckbox = new QCheckBox("Use legacy ports");
-    m_useLegacyPortsCheckbox->setToolTip(
-        "Use legacy ports, refer to AIRPLAY.md for more information.");
+    m_useLegacyPortsCheckbox = new QCheckBox();
     airplayLayout->addWidget(m_useLegacyPortsCheckbox);
 
-    m_showV4L2CheckBox = new QCheckBox("Show V4L2 Button on AirPlay Widget");
+    m_showV4L2CheckBox = new QCheckBox();
     airplayLayout->addWidget(m_showV4L2CheckBox);
 #endif
 
-    scrollLayout->addWidget(airplayGroup);
+    scrollLayout->addWidget(m_airplayGroup);
 
     // === MISCELLANEOUS SETTINGS ===
-    auto *miscGroup = new QGroupBox("Miscellaneous");
-    auto *miscLayout = new QVBoxLayout(miscGroup);
+    m_miscGroup = new QGroupBox();
+    auto *miscLayout = new QVBoxLayout(m_miscGroup);
 
     auto *iconSizeBaseMultiplierLayout = new QHBoxLayout();
     m_iconSizeBaseMultiplier = new QDoubleSpinBox();
@@ -254,31 +271,22 @@ void SettingsWidget::setupUI()
     m_iconSizeBaseMultiplier->setSingleStep(0.1);
     m_iconSizeBaseMultiplier->setDecimals(1);
     m_iconSizeBaseMultiplier->setSuffix("x");
-    m_iconSizeBaseMultiplier->setToolTip(
-        "Adjust the base multiplier for icon sizes. This affects how large "
-        "icons appear throughout the application. Requires restart to take "
-        "effect.");
 
-    iconSizeBaseMultiplierLayout->addWidget(
-        new QLabel("Icon Size Base Multiplier:"));
+    m_iconSizeBaseMultiplierLabel = new QLabel();
+    iconSizeBaseMultiplierLayout->addWidget(m_iconSizeBaseMultiplierLabel);
     iconSizeBaseMultiplierLayout->addWidget(m_iconSizeBaseMultiplier);
     iconSizeBaseMultiplierLayout->addStretch();
     miscLayout->addLayout(iconSizeBaseMultiplierLayout);
 
-    scrollLayout->addWidget(miscGroup);
+    scrollLayout->addWidget(m_miscGroup);
 
     scrollLayout->addSpacing(30);
 
     // Add a footer Author & Version & app info & app description
-    auto *footerLabel = new QLabel(
-        QString(
-            "iDescriptor v%1\n"
-            "A free, open-source, and cross-platform iDevice management tool.\n"
-            "© 2026 See AUTHORS for details. Licensed under AGPLv3.")
-            .arg(APP_VERSION));
-    footerLabel->setAlignment(Qt::AlignCenter);
-    footerLabel->setStyleSheet("color: gray; font-size: 8pt;");
-    scrollLayout->addWidget(footerLabel);
+    m_footerLabel = new QLabel();
+    m_footerLabel->setAlignment(Qt::AlignCenter);
+    m_footerLabel->setStyleSheet("color: gray; font-size: 8pt;");
+    scrollLayout->addWidget(m_footerLabel);
 
     // Add stretch to push everything to the top
     scrollLayout->addStretch();
@@ -291,9 +299,9 @@ void SettingsWidget::setupUI()
     // == BUTTONS ===
     auto *buttonLayout = new QHBoxLayout();
 
-    m_checkUpdatesButton = new QPushButton("Check for Updates");
-    m_resetButton = new QPushButton("Reset Settings");
-    m_applyButton = new QPushButton("Apply");
+    m_checkUpdatesButton = new QPushButton();
+    m_resetButton = new QPushButton();
+    m_applyButton = new QPushButton();
 
     buttonLayout->addWidget(m_checkUpdatesButton);
     buttonLayout->addWidget(m_resetButton);
@@ -312,6 +320,142 @@ void SettingsWidget::setupUI()
             &SettingsWidget::onApplyClicked);
 }
 
+void SettingsWidget::retranslateUi()
+{
+    setWindowTitle(tr("Settings"));
+
+    // === GENERAL ===
+    m_generalGroup->setTitle(tr("General"));
+    m_downloadPathLabel->setText(tr("Download Path:"));
+    m_browseButton->setText(tr("Browse..."));
+    m_wirelessFileServerPortLabel->setText(tr("Wireless File Server Port:"));
+    m_wirelessFileServerPort->setToolTip(
+        tr("The starting port for the wireless file server. If this port is "
+           "unavailable, it will try the next 10 ports."));
+
+#ifndef __APPLE__
+    m_unmount_iFuseDrives->setText(tr("Unmount iFuse drives on exit"));
+#endif
+
+    m_autoUpdateCheck->setText(tr("Automatically check for updates"));
+    m_autoEnableWifiConnections->setText(
+        tr("Automatically enable Wi-Fi connections"));
+
+    m_themeLabel->setText(tr("Theme:"));
+    for (int i = 0; i < m_themeCombo->count(); ++i) {
+        const QString id = m_themeCombo->itemData(i).toString();
+        if (id == QLatin1String(IDESC_THEME_SYSTEM_DEFAULT)) {
+            m_themeCombo->setItemText(i, tr("System Default"));
+        } else {
+            // Future-proof fallback: display the identifier itself.
+            m_themeCombo->setItemText(i, id);
+        }
+    }
+
+    m_languageLabel->setText(tr("Language:"));
+    for (int i = 0; i < m_languageCombo->count(); ++i) {
+        const QString code = m_languageCombo->itemData(i).toString();
+        m_languageCombo->setItemText(i, TranslationManager::displayName(code));
+    }
+
+#ifdef WIN32
+    if (m_backDropTypeLabel) {
+        m_backDropTypeLabel->setText(tr("Backdrop Type:"));
+    }
+    if (m_backDropTypeCombo) {
+        for (int i = 0; i < m_backDropTypeCombo->count(); ++i) {
+            const QVariant data = m_backDropTypeCombo->itemData(i);
+            if (data.typeId() == QMetaType::QString
+                && data.toString() == QLatin1String(IDESC_BACKDROP_AUTO)) {
+                //: Backdrop type that defers to the platform default.
+                m_backDropTypeCombo->setItemText(i, tr("Auto", "Backdrop type"));
+            } else {
+                const int value = data.toInt();
+                if (value == static_cast<int>(MICA)) {
+                    m_backDropTypeCombo->setItemText(i, tr("Mica"));
+                } else if (value == static_cast<int>(MICA_ALT)) {
+                    m_backDropTypeCombo->setItemText(i, tr("Mica Alt"));
+                } else if (value == static_cast<int>(ACRYLIC)) {
+                    m_backDropTypeCombo->setItemText(i, tr("Acrylic"));
+                }
+            }
+        }
+    }
+    if (m_disableMicaCheckBox) {
+        m_disableMicaCheckBox->setText(
+            tr("Disable Mica effects (also disables WinUI styles)"));
+    }
+#endif
+
+    // === DEVICE CONNECTION ===
+    m_deviceGroup->setTitle(tr("Device Connection"));
+    m_autoRaiseWindow->setText(
+        tr("Auto-raise main window on device connection"));
+    m_switchToNewDevice->setText(tr("Switch to newly connected device"));
+    m_autoConnectWirelessDevices->setText(
+        tr("Automatically connect to wireless devices"));
+    m_connectionTimeoutLabel->setText(tr("Connection Timeout:"));
+    m_connectionTimeout->setSuffix(tr(" seconds"));
+
+    // === SECURITY ===
+    m_securityGroup->setTitle(tr("Security"));
+    m_useUnsecureBackend->setText(
+        tr("Use unsecure backend for app store (ipatool)"));
+    m_useUnsecureBackend->setToolTip(
+        tr("Enabling this may put your Apple account at risk but you don't "
+           "have to deal with Apple keychain."));
+
+    // === JAILBROKEN ===
+    m_jailbrokenGroup->setTitle(tr("Jailbroken"));
+    m_defaultJailbrokenRootPasswordLabel->setText(
+        tr("Default Jailbroken Root Password:"));
+    m_defaultJailbrokenRootPassword->setToolTip(
+        tr("Default password used for SSH root authentication on jailbroken "
+           "devices: Default is 'alpine'."));
+
+    // === AIRPLAY ===
+    m_airplayGroup->setTitle(tr("AirPlay"));
+    m_fpsLabel->setText(tr("Fps:"));
+    m_fpsComboBox->setToolTip(
+        tr("Set the fps for AirPlay. Go with 30 fps if have an older device."));
+    m_noHoldCheckbox->setText(tr("Allow New Connections to Take Over"));
+
+#ifdef __linux__
+    m_useLegacyPortsCheckbox->setText(tr("Use legacy ports"));
+    m_useLegacyPortsCheckbox->setToolTip(
+        tr("Use legacy ports, refer to AIRPLAY.md for more information."));
+    m_showV4L2CheckBox->setText(tr("Show V4L2 Button on AirPlay Widget"));
+#endif
+
+    // === MISCELLANEOUS ===
+    m_miscGroup->setTitle(tr("Miscellaneous"));
+    m_iconSizeBaseMultiplierLabel->setText(tr("Icon Size Base Multiplier:"));
+    m_iconSizeBaseMultiplier->setToolTip(
+        tr("Adjust the base multiplier for icon sizes. This affects how large "
+           "icons appear throughout the application. Requires restart to take "
+           "effect."));
+
+    // === FOOTER ===
+    m_footerLabel->setText(
+        tr("iDescriptor v%1\n"
+           "A free, open-source, and cross-platform iDevice management tool.\n"
+           "\xC2\xA9 2026 See AUTHORS for details. Licensed under AGPLv3.")
+            .arg(QStringLiteral(APP_VERSION)));
+
+    // === BUTTONS ===
+    m_checkUpdatesButton->setText(tr("Check for Updates"));
+    m_resetButton->setText(tr("Reset Settings"));
+    m_applyButton->setText(tr("Apply"));
+}
+
+void SettingsWidget::changeEvent(QEvent *event)
+{
+    if (event->type() == QEvent::LanguageChange) {
+        retranslateUi();
+    }
+    QDialog::changeEvent(event);
+}
+
 void SettingsWidget::loadSettings()
 {
     SettingsManager *sm = SettingsManager::sharedInstance();
@@ -328,12 +472,24 @@ void SettingsWidget::loadSettings()
     m_unmount_iFuseDrives->setChecked(sm->unmountiFuseOnExit());
 #endif
 
-    // Set theme combo box
-    QString currentTheme = sm->theme();
-    int themeIndex = m_themeCombo->findText(currentTheme);
+    // Theme combo: match by locale-independent userData identifier so the
+    // saved value keeps resolving correctly across language changes.
+    const QString currentTheme = sm->theme();
+    int themeIndex = m_themeCombo->findData(currentTheme);
+    if (themeIndex == -1) {
+        // Backwards-compatible fallback for values stored before the
+        // identifier scheme landed (which used the displayed text).
+        themeIndex = m_themeCombo->findText(currentTheme);
+    }
     if (themeIndex != -1) {
         m_themeCombo->setCurrentIndex(themeIndex);
     }
+
+    // Language combo: select the persisted locale code.
+    const QString currentLocale =
+        TranslationManager::sharedInstance()->currentLocaleCode();
+    const int languageIndex = m_languageCombo->findData(currentLocale);
+    m_languageCombo->setCurrentIndex(languageIndex >= 0 ? languageIndex : 0);
 
     m_connectionTimeout->setValue(sm->connectionTimeout());
     m_useUnsecureBackend->setChecked(sm->useUnsecureBackend());
@@ -386,6 +542,9 @@ void SettingsWidget::connectSignals()
 #endif
     connect(m_themeCombo, QOverload<int>::of(&QComboBox::currentIndexChanged),
             this, &SettingsWidget::onSettingChanged);
+    connect(m_languageCombo,
+            QOverload<int>::of(&QComboBox::currentIndexChanged), this,
+            &SettingsWidget::onSettingChanged);
     connect(m_connectionTimeout, QOverload<int>::of(&QSpinBox::valueChanged),
             this, &SettingsWidget::onSettingChanged);
     connect(m_wirelessFileServerPort,
@@ -403,10 +562,10 @@ void SettingsWidget::connectSignals()
         // since this is unsafe if its being enabled, show a warning
         if (m_useUnsecureBackend->isChecked()) {
             auto reply = QMessageBox::warning(
-                this, "Warning",
-                "Enabling this will not encrypt your Apple account which "
-                "is a "
-                "security risk. Are you sure you want to enable this?",
+                this, tr("Warning"),
+                tr("Enabling this will not encrypt your Apple account which "
+                   "is a "
+                   "security risk. Are you sure you want to enable this?"),
                 QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
 
             if (reply == QMessageBox::Yes) {
@@ -454,7 +613,7 @@ void SettingsWidget::connectSignals()
 void SettingsWidget::onBrowseButtonClicked()
 {
     QString dir = QFileDialog::getExistingDirectory(
-        this, "Select Download Directory", m_downloadPathEdit->text(),
+        this, tr("Select Download Directory"), m_downloadPathEdit->text(),
         QFileDialog::ShowDirsOnly);
 
     if (!dir.isEmpty()) {
@@ -465,18 +624,18 @@ void SettingsWidget::onBrowseButtonClicked()
 
 void SettingsWidget::onCheckUpdatesClicked()
 {
-    m_checkUpdatesButton->setText("Checking...");
+    m_checkUpdatesButton->setText(tr("Checking..."));
     m_checkUpdatesButton->setEnabled(false);
 
     connect(
         MainWindow::sharedInstance()->m_updater, &ZUpdater::dataAvailable, this,
         [this](const QJsonDocument data, bool isUpdateAvailable) {
             if (!isUpdateAvailable) {
-                QMessageBox::information(this, "No Updates",
-                                         "You are using the latest version of "
-                                         "iDescriptor.");
+                QMessageBox::information(this, tr("No Updates"),
+                                         tr("You are using the latest version "
+                                            "of iDescriptor."));
             }
-            m_checkUpdatesButton->setText("Check for Updates");
+            m_checkUpdatesButton->setText(tr("Check for Updates"));
             m_checkUpdatesButton->setEnabled(true);
         },
         Qt::SingleShotConnection);
@@ -487,8 +646,9 @@ void SettingsWidget::onCheckUpdatesClicked()
 void SettingsWidget::onResetToDefaultsClicked()
 {
     auto reply = QMessageBox::question(
-        this, "Reset Settings",
-        "Are you sure you want to reset all settings to their default values?",
+        this, tr("Reset Settings"),
+        tr("Are you sure you want to reset all settings to their default "
+           "values?"),
         QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
 
     if (reply == QMessageBox::Yes) {
@@ -499,12 +659,12 @@ void SettingsWidget::onResetToDefaultsClicked()
 void SettingsWidget::onApplyClicked()
 {
     saveSettings();
-    QMessageBox::information(this, "Settings",
+    QMessageBox::information(this, tr("Settings"),
                              m_restartRequired
-                                 ? "Settings applied. Please restart "
-                                   "the application for changes to "
-                                   "take effect."
-                                 : "Settings applied.");
+                                 ? tr("Settings applied. Please restart "
+                                      "the application for changes to "
+                                      "take effect.")
+                                 : tr("Settings applied."));
     m_restartRequired = false;
 }
 
@@ -532,7 +692,10 @@ void SettingsWidget::saveSettings()
 #endif
     sm->setUseUnsecureBackend(m_useUnsecureBackend->isChecked());
 
-    sm->setTheme(m_themeCombo->currentText());
+    // Persist the locale-independent identifier carried in userData so the
+    // stored value keeps resolving across language changes.
+    const QString themeId = m_themeCombo->currentData().toString();
+    sm->setTheme(themeId.isEmpty() ? m_themeCombo->currentText() : themeId);
     sm->setConnectionTimeout(m_connectionTimeout->value());
     sm->setDefaultJailbrokenRootPassword(
         m_defaultJailbrokenRootPassword->text());
@@ -545,13 +708,26 @@ void SettingsWidget::saveSettings()
     sm->setAirplayUseLegacyPorts(m_useLegacyPortsCheckbox->isChecked());
     sm->setShowV4L2(m_showV4L2CheckBox->isChecked());
 #endif
+
+    // Apply the selected locale. TranslationManager::setLocale persists the
+    // value via SettingsManager and broadcasts a LanguageChange event.
+    const QString newLocale = m_languageCombo->currentData().toString();
+    if (newLocale
+        != TranslationManager::sharedInstance()->currentLocaleCode()) {
+        TranslationManager::sharedInstance()->setLocale(newLocale);
+    }
+
     m_applyButton->setEnabled(false);
 
 #ifdef WIN32
     if (m_backDropTypeCombo) {
         const QVariant data = m_backDropTypeCombo->currentData();
-        if (!data.isValid()) {
+        // The "Auto" entry stores the literal string identifier; everything
+        // else stores the WIN_BACKDROP int.
+        if (data.typeId() == QMetaType::QString) {
             // AUTO = ACRYLIC
+            sm->setWinBackdropType(static_cast<WIN_BACKDROP>(ACRYLIC));
+        } else if (!data.isValid()) {
             sm->setWinBackdropType(static_cast<WIN_BACKDROP>(ACRYLIC));
         } else {
             sm->setWinBackdropType(static_cast<WIN_BACKDROP>(data.toInt()));

--- a/src/settingswidget.h
+++ b/src/settingswidget.h
@@ -23,10 +23,16 @@
 #include <QCheckBox>
 #include <QComboBox>
 #include <QDialog>
+#include <QGroupBox>
+#include <QLabel>
 #include <QLineEdit>
 #include <QPushButton>
 #include <QSpinBox>
 #include <QWidget>
+
+QT_BEGIN_NAMESPACE
+class QEvent;
+QT_END_NAMESPACE
 
 class SettingsWidget : public QDialog
 {
@@ -34,6 +40,9 @@ class SettingsWidget : public QDialog
 
 public:
     explicit SettingsWidget(QWidget *parent = nullptr);
+
+protected:
+    void changeEvent(QEvent *event) override;
 
 private slots:
     void onBrowseButtonClicked();
@@ -48,13 +57,21 @@ private:
     void saveSettings();
     void connectSignals();
     void resetToDefaults();
+    void retranslateUi();
 
     // UI Elements
     // General
+    QGroupBox *m_generalGroup;
+    QLabel *m_downloadPathLabel;
     QLineEdit *m_downloadPathEdit;
+    QPushButton *m_browseButton;
+    QLabel *m_wirelessFileServerPortLabel;
     QSpinBox *m_wirelessFileServerPort;
     QCheckBox *m_autoUpdateCheck;
+    QLabel *m_themeLabel;
     QComboBox *m_themeCombo;
+    QLabel *m_languageLabel;
+    QComboBox *m_languageCombo;
     QCheckBox *m_autoRaiseWindow;
     QCheckBox *m_switchToNewDevice;
     QCheckBox *m_autoEnableWifiConnections;
@@ -63,15 +80,27 @@ private:
 #endif
     QCheckBox *m_useUnsecureBackend;
     // Device Connection
+    QGroupBox *m_deviceGroup;
     QCheckBox *m_autoConnectWirelessDevices;
+    QLabel *m_connectionTimeoutLabel;
     QSpinBox *m_connectionTimeout;
 
+    // Security
+    QGroupBox *m_securityGroup;
+
     // Jailbroken
+    QGroupBox *m_jailbrokenGroup;
+    QLabel *m_defaultJailbrokenRootPasswordLabel;
     QLineEdit *m_defaultJailbrokenRootPassword;
 
+    // Miscellaneous
+    QGroupBox *m_miscGroup;
+    QLabel *m_iconSizeBaseMultiplierLabel;
     QDoubleSpinBox *m_iconSizeBaseMultiplier;
 
     // Airplay
+    QGroupBox *m_airplayGroup;
+    QLabel *m_fpsLabel;
     QComboBox *m_fpsComboBox;
     QCheckBox *m_noHoldCheckbox;
 
@@ -81,9 +110,13 @@ private:
 #endif
 
 #ifdef WIN32
+    QLabel *m_backDropTypeLabel;
     QComboBox *m_backDropTypeCombo;
     QCheckBox *m_disableMicaCheckBox;
 #endif
+
+    // Footer
+    QLabel *m_footerLabel;
 
     // Buttons
     QPushButton *m_checkUpdatesButton;

--- a/src/translationmanager.cpp
+++ b/src/translationmanager.cpp
@@ -1,0 +1,126 @@
+/*
+ * iDescriptor: A free and open-source idevice management tool.
+ *
+ * Copyright (C) 2025 Uncore <https://github.com/uncor3>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "translationmanager.h"
+
+#include "settingsmanager.h"
+
+#include <QCoreApplication>
+#include <QDebug>
+#include <QLibraryInfo>
+#include <QTranslator>
+
+TranslationManager *TranslationManager::sharedInstance()
+{
+    static TranslationManager instance;
+    return &instance;
+}
+
+TranslationManager::TranslationManager(QObject *parent) : QObject{parent}
+{
+}
+
+QStringList TranslationManager::availableLocaleCodes()
+{
+    return QStringList{QStringLiteral(""), QStringLiteral("en"),
+                       QStringLiteral("ja"), QStringLiteral("zh_CN")};
+}
+
+QString TranslationManager::displayName(const QString &code)
+{
+    if (code.isEmpty()) {
+        return tr("System");
+    }
+    if (code == QStringLiteral("en")) {
+        return QStringLiteral("English");
+    }
+    if (code == QStringLiteral("ja")) {
+        return QStringLiteral("日本語");
+    }
+    if (code == QStringLiteral("zh_CN")) {
+        return QStringLiteral("简体中文");
+    }
+    return code;
+}
+
+void TranslationManager::initFromSettings()
+{
+    const QString persisted = SettingsManager::sharedInstance()->language();
+    m_currentCode = persisted;
+    applyLocale(persisted);
+}
+
+void TranslationManager::setLocale(const QString &code)
+{
+    if (code == m_currentCode && (m_appTranslator || m_qtTranslator)) {
+        return;
+    }
+
+    applyLocale(code);
+    m_currentCode = code;
+    SettingsManager::sharedInstance()->setLanguage(code);
+    emit localeChanged(code);
+}
+
+QString TranslationManager::currentLocaleCode() const
+{
+    return m_currentCode;
+}
+
+QLocale TranslationManager::resolveLocale(const QString &code) const
+{
+    if (code.isEmpty()) {
+        return QLocale::system();
+    }
+    return QLocale(code);
+}
+
+void TranslationManager::applyLocale(const QString &code)
+{
+    if (m_appTranslator) {
+        QCoreApplication::removeTranslator(m_appTranslator);
+        m_appTranslator->deleteLater();
+        m_appTranslator = nullptr;
+    }
+    if (m_qtTranslator) {
+        QCoreApplication::removeTranslator(m_qtTranslator);
+        m_qtTranslator->deleteLater();
+        m_qtTranslator = nullptr;
+    }
+
+    const QLocale locale = resolveLocale(code);
+
+    m_appTranslator = new QTranslator(this);
+    if (!m_appTranslator->load(locale, QStringLiteral("idescriptor"),
+                               QStringLiteral("_"),
+                               QStringLiteral(":/i18n"))) {
+        qWarning() << "TranslationManager: failed to load app translation for"
+                   << locale.name();
+    }
+    QCoreApplication::installTranslator(m_appTranslator);
+
+    m_qtTranslator = new QTranslator(this);
+    if (!m_qtTranslator->load(
+            locale, QStringLiteral("qt"), QStringLiteral("_"),
+            QLibraryInfo::path(QLibraryInfo::TranslationsPath))) {
+        qWarning() << "TranslationManager: failed to load Qt translation for"
+                   << locale.name();
+    }
+    QCoreApplication::installTranslator(m_qtTranslator);
+}

--- a/src/translationmanager.h
+++ b/src/translationmanager.h
@@ -1,0 +1,74 @@
+/*
+ * iDescriptor: A free and open-source idevice management tool.
+ *
+ * Copyright (C) 2025 Uncore <https://github.com/uncor3>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef TRANSLATIONMANAGER_H
+#define TRANSLATIONMANAGER_H
+
+#include <QLocale>
+#include <QObject>
+#include <QString>
+#include <QStringList>
+
+class QTranslator;
+
+class TranslationManager : public QObject
+{
+    Q_OBJECT
+
+public:
+    static TranslationManager *sharedInstance();
+
+    // Locale codes bundled with the app. The empty string acts as a sentinel
+    // meaning "follow the host system locale".
+    static QStringList availableLocaleCodes();
+
+    // Human-readable label for a code, suitable for a Settings combo box.
+    // Empty string maps to tr("System"); known codes map to their endonyms.
+    static QString displayName(const QString &code);
+
+    // Initialise translators from persisted settings (or system locale).
+    // Must be called from main() right after QApplication construction and
+    // QCoreApplication::setOrganizationName/setApplicationName.
+    void initFromSettings();
+
+    // Apply a locale immediately and persist the choice. An empty string
+    // resets the override to the system locale.
+    void setLocale(const QString &code);
+
+    // Persisted override ("" if following the system locale).
+    QString currentLocaleCode() const;
+
+signals:
+    void localeChanged(const QString &code);
+
+private:
+    explicit TranslationManager(QObject *parent = nullptr);
+
+    // Helper: resolves "" / specific code into the QLocale we should load.
+    QLocale resolveLocale(const QString &code) const;
+
+    // Internal: install translators for the given code (does not persist).
+    void applyLocale(const QString &code);
+
+    QTranslator *m_appTranslator = nullptr;
+    QTranslator *m_qtTranslator = nullptr;
+    QString m_currentCode;
+};
+
+#endif // TRANSLATIONMANAGER_H

--- a/translations/idescriptor_en.ts
+++ b/translations/idescriptor_en.ts
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="en_US">
+</TS>

--- a/translations/idescriptor_ja.ts
+++ b/translations/idescriptor_ja.ts
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ja_JP">
+</TS>

--- a/translations/idescriptor_ja.ts
+++ b/translations/idescriptor_ja.ts
@@ -1,4 +1,364 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
 <TS version="2.1" language="ja_JP">
+<context>
+    <name>MainWindow</name>
+    <message>
+        <source>iDevice</source>
+        <translation>iDevice</translation>
+    </message>
+    <message>
+        <source>Apps</source>
+        <translation>App</translation>
+    </message>
+    <message>
+        <source>Toolbox</source>
+        <translation>ツールボックス</translation>
+    </message>
+    <message>
+        <source>Jailbroken</source>
+        <translation>脱獄</translation>
+    </message>
+    <message>
+        <source>Settings</source>
+        <translation>設定</translation>
+    </message>
+    <message>
+        <source>%1 on GitHub</source>
+        <translation>GitHub で %1 を見る</translation>
+    </message>
+    <message>
+        <source>%1: no devices</source>
+        <translation>%1: デバイスなし</translation>
+    </message>
+    <message>
+        <source>Switch to Welcome Menu</source>
+        <translation>ようこそメニューに切り替え</translation>
+    </message>
+    <message>
+        <source>Switch to Connected Devices</source>
+        <translation>接続中のデバイスに切り替え</translation>
+    </message>
+    <message>
+        <source>Unmount Failed</source>
+        <translation>アンマウントに失敗しました</translation>
+    </message>
+    <message>
+        <source>Failed to unmount iFuse at %1. Please try again.</source>
+        <translation>%1 の iFuse をアンマウントできませんでした。もう一度お試しください。</translation>
+    </message>
+    <message>
+        <source>New portable version downloaded, app location will be shown after this message</source>
+        <translation>新しいポータブル版をダウンロードしました。このメッセージの後にアプリの場所を表示します。</translation>
+    </message>
+    <message>
+        <source>The application will now quit to install the update.</source>
+        <translation>アップデートをインストールするためにアプリケーションを終了します。</translation>
+    </message>
+    <message>
+        <source>New portable version downloaded</source>
+        <translation>新しいポータブル版をダウンロードしました</translation>
+    </message>
+    <message>
+        <source>Do you want to install the downloaded update now?</source>
+        <translation>ダウンロードしたアップデートを今すぐインストールしますか？</translation>
+    </message>
+    <message>
+        <source>The application will now quit and open .dmg file downloaded to &quot;Downloads&quot; from there you can drag it to Applications to install.</source>
+        <translation>アプリケーションを終了し、「ダウンロード」フォルダにある .dmg ファイルを開きます。そこからアプリケーションフォルダにドラッグしてインストールしてください。</translation>
+    </message>
+    <message>
+        <source>Update downloaded would you like to quit and install the update?</source>
+        <translation>アップデートをダウンロードしました。終了してインストールしますか？</translation>
+    </message>
+    <message>
+        <source>AppImages we ship are not updateable. New version is downloaded to &quot;Downloads&quot;. You can start using the new version by launching it from there. You can delete this AppImage version if you like.</source>
+        <translation>配布している AppImage は自動更新に対応していません。新しいバージョンは「ダウンロード」フォルダに保存されています。そこから起動して新しいバージョンを利用できます。この AppImage は削除しても構いません。</translation>
+    </message>
+    <message>
+        <source>Update downloaded would you like to quit and open the new version?</source>
+        <translation>アップデートをダウンロードしました。終了して新しいバージョンを開きますか？</translation>
+    </message>
+    <message>
+        <source>You seem to have installed %1 using a package manager. Please use %2 to update it.</source>
+        <translation>%1 はパッケージマネージャー経由でインストールされているようです。アップデートには %2 を使用してください。</translation>
+    </message>
+    <message>
+        <source>&amp;Help</source>
+        <translation>ヘルプ(&amp;H)</translation>
+    </message>
+    <message>
+        <source>&amp;About %1</source>
+        <translation>%1 について(&amp;A)</translation>
+    </message>
+    <message numerus="yes">
+        <source>%1: %n device(s) connected</source>
+        <translation>
+            <numerusform>%1: %n 台のデバイスが接続されています</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>About %1</source>
+        <translation>%1 について</translation>
+    </message>
+    <message>
+        <source>A free, open-source, and cross-platform iDevice management tool.</source>
+        <translation>無料・オープンソース・クロスプラットフォームの iDevice 管理ツールです。</translation>
+    </message>
+    <message>
+        <source>Transfers in Progress</source>
+        <translation>転送中</translation>
+    </message>
+    <message>
+        <source>There are import/export operations in progress.
+Do you really want to quit? This will cancel them.</source>
+        <translation>インポート／エクスポートの処理が進行中です。
+本当に終了しますか？処理はキャンセルされます。</translation>
+    </message>
+</context>
+<context>
+    <name>SettingsManager</name>
+    <message>
+        <source>Settings - iDescriptor</source>
+        <translation>設定 - iDescriptor</translation>
+    </message>
+</context>
+<context>
+    <name>SettingsWidget</name>
+    <message>
+        <source>Settings</source>
+        <translation>設定</translation>
+    </message>
+    <message>
+        <source>General</source>
+        <translation>一般</translation>
+    </message>
+    <message>
+        <source>Download Path:</source>
+        <translation>ダウンロード先:</translation>
+    </message>
+    <message>
+        <source>Browse...</source>
+        <translation>参照...</translation>
+    </message>
+    <message>
+        <source>Wireless File Server Port:</source>
+        <translation>ワイヤレスファイルサーバーのポート:</translation>
+    </message>
+    <message>
+        <source>The starting port for the wireless file server. If this port is unavailable, it will try the next 10 ports.</source>
+        <translation>ワイヤレスファイルサーバーの開始ポートです。このポートが使用できない場合、次の 10 個のポートを順に試行します。</translation>
+    </message>
+    <message>
+        <source>Unmount iFuse drives on exit</source>
+        <translation>終了時に iFuse ドライブをアンマウントする</translation>
+    </message>
+    <message>
+        <source>Automatically check for updates</source>
+        <translation>アップデートを自動的に確認する</translation>
+    </message>
+    <message>
+        <source>Automatically enable Wi-Fi connections</source>
+        <translation>Wi-Fi 接続を自動的に有効化する</translation>
+    </message>
+    <message>
+        <source>Theme:</source>
+        <translation>テーマ:</translation>
+    </message>
+    <message>
+        <source>System Default</source>
+        <translation>システム設定に従う</translation>
+    </message>
+    <message>
+        <source>Language:</source>
+        <translation>言語:</translation>
+    </message>
+    <message>
+        <source>Backdrop Type:</source>
+        <translation>背景効果の種類:</translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <comment>Backdrop type</comment>
+        <translation>自動</translation>
+    </message>
+    <message>
+        <source>Mica</source>
+        <translation>Mica</translation>
+    </message>
+    <message>
+        <source>Mica Alt</source>
+        <translation>Mica Alt</translation>
+    </message>
+    <message>
+        <source>Acrylic</source>
+        <translation>Acrylic</translation>
+    </message>
+    <message>
+        <source>Disable Mica effects (also disables WinUI styles)</source>
+        <translation>Mica 効果を無効化する（WinUI スタイルも無効化されます）</translation>
+    </message>
+    <message>
+        <source>Device Connection</source>
+        <translation>デバイス接続</translation>
+    </message>
+    <message>
+        <source>Auto-raise main window on device connection</source>
+        <translation>デバイス接続時にメインウィンドウを前面に表示する</translation>
+    </message>
+    <message>
+        <source>Switch to newly connected device</source>
+        <translation>新しく接続されたデバイスに切り替える</translation>
+    </message>
+    <message>
+        <source>Automatically connect to wireless devices</source>
+        <translation>ワイヤレスデバイスに自動的に接続する</translation>
+    </message>
+    <message>
+        <source>Connection Timeout:</source>
+        <translation>接続タイムアウト:</translation>
+    </message>
+    <message>
+        <source> seconds</source>
+        <translation> 秒</translation>
+    </message>
+    <message>
+        <source>Security</source>
+        <translation>セキュリティ</translation>
+    </message>
+    <message>
+        <source>Use unsecure backend for app store (ipatool)</source>
+        <translation>App Store に安全でないバックエンドを使用する (ipatool)</translation>
+    </message>
+    <message>
+        <source>Enabling this may put your Apple account at risk but you don&apos;t have to deal with Apple keychain.</source>
+        <translation>有効にすると Apple アカウントが危険にさらされる可能性がありますが、Apple のキーチェーンを扱う必要はありません。</translation>
+    </message>
+    <message>
+        <source>Jailbroken</source>
+        <translation>脱獄</translation>
+    </message>
+    <message>
+        <source>Default Jailbroken Root Password:</source>
+        <translation>脱獄デバイスの既定 root パスワード:</translation>
+    </message>
+    <message>
+        <source>Default password used for SSH root authentication on jailbroken devices: Default is &apos;alpine&apos;.</source>
+        <translation>脱獄デバイスへの SSH root 認証で使用する既定のパスワードです。デフォルトは「alpine」です。</translation>
+    </message>
+    <message>
+        <source>AirPlay</source>
+        <translation>AirPlay</translation>
+    </message>
+    <message>
+        <source>Fps:</source>
+        <translation>FPS:</translation>
+    </message>
+    <message>
+        <source>Set the fps for AirPlay. Go with 30 fps if have an older device.</source>
+        <translation>AirPlay の FPS を設定します。古いデバイスの場合は 30 fps を選択してください。</translation>
+    </message>
+    <message>
+        <source>Allow New Connections to Take Over</source>
+        <translation>新しい接続による乗っ取りを許可する</translation>
+    </message>
+    <message>
+        <source>Use legacy ports</source>
+        <translation>レガシーポートを使用する</translation>
+    </message>
+    <message>
+        <source>Use legacy ports, refer to AIRPLAY.md for more information.</source>
+        <translation>レガシーポートを使用します。詳細は AIRPLAY.md を参照してください。</translation>
+    </message>
+    <message>
+        <source>Show V4L2 Button on AirPlay Widget</source>
+        <translation>AirPlay ウィジェットに V4L2 ボタンを表示する</translation>
+    </message>
+    <message>
+        <source>Miscellaneous</source>
+        <translation>その他</translation>
+    </message>
+    <message>
+        <source>Icon Size Base Multiplier:</source>
+        <translation>アイコンサイズの基本倍率:</translation>
+    </message>
+    <message>
+        <source>Adjust the base multiplier for icon sizes. This affects how large icons appear throughout the application. Requires restart to take effect.</source>
+        <translation>アイコンサイズの基本倍率を調整します。アプリケーション全体のアイコンの大きさに影響します。反映には再起動が必要です。</translation>
+    </message>
+    <message>
+        <source>iDescriptor v%1
+A free, open-source, and cross-platform iDevice management tool.
+© 2026 See AUTHORS for details. Licensed under AGPLv3.</source>
+        <translation>iDescriptor v%1
+無料・オープンソース・クロスプラットフォームの iDevice 管理ツールです。
+© 2026 詳細は AUTHORS を参照してください。AGPLv3 ライセンスで提供されています。</translation>
+    </message>
+    <message>
+        <source>Check for Updates</source>
+        <translation>アップデートを確認</translation>
+    </message>
+    <message>
+        <source>Reset Settings</source>
+        <translation>設定をリセット</translation>
+    </message>
+    <message>
+        <source>Apply</source>
+        <translation>適用</translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation>警告</translation>
+    </message>
+    <message>
+        <source>Enabling this will not encrypt your Apple account which is a security risk. Are you sure you want to enable this?</source>
+        <translation>有効にすると Apple アカウントが暗号化されず、セキュリティ上のリスクとなります。本当に有効化しますか？</translation>
+    </message>
+    <message>
+        <source>Select Download Directory</source>
+        <translation>ダウンロード先ディレクトリを選択</translation>
+    </message>
+    <message>
+        <source>Checking...</source>
+        <translation>確認中...</translation>
+    </message>
+    <message>
+        <source>No Updates</source>
+        <translation>アップデートはありません</translation>
+    </message>
+    <message>
+        <source>You are using the latest version of iDescriptor.</source>
+        <translation>iDescriptor は最新バージョンです。</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to reset all settings to their default values?</source>
+        <translation>すべての設定を既定値にリセットしますか？</translation>
+    </message>
+    <message>
+        <source>Settings applied. Please restart the application for changes to take effect.</source>
+        <translation>設定を適用しました。変更を反映するにはアプリケーションを再起動してください。</translation>
+    </message>
+    <message>
+        <source>Settings applied.</source>
+        <translation>設定を適用しました。</translation>
+    </message>
+</context>
+<context>
+    <name>TranslationManager</name>
+    <message>
+        <source>System</source>
+        <translation>システム</translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <source>Settings Reset</source>
+        <translation>設定をリセット</translation>
+    </message>
+    <message>
+        <source>All application settings have been reset to their default values.</source>
+        <translation>すべてのアプリケーション設定が既定値にリセットされました。</translation>
+    </message>
+</context>
 </TS>

--- a/translations/idescriptor_zh_CN.ts
+++ b/translations/idescriptor_zh_CN.ts
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_CN">
+</TS>

--- a/translations/idescriptor_zh_CN.ts
+++ b/translations/idescriptor_zh_CN.ts
@@ -1,4 +1,364 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
 <TS version="2.1" language="zh_CN">
+<context>
+    <name>MainWindow</name>
+    <message>
+        <source>iDevice</source>
+        <translation type="unfinished">iDevice</translation>
+    </message>
+    <message>
+        <source>Apps</source>
+        <translation type="unfinished">应用</translation>
+    </message>
+    <message>
+        <source>Toolbox</source>
+        <translation type="unfinished">工具箱</translation>
+    </message>
+    <message>
+        <source>Jailbroken</source>
+        <translation type="unfinished">越狱</translation>
+    </message>
+    <message>
+        <source>Settings</source>
+        <translation type="unfinished">设置</translation>
+    </message>
+    <message>
+        <source>%1 on GitHub</source>
+        <translation type="unfinished">在 GitHub 上查看 %1</translation>
+    </message>
+    <message>
+        <source>%1: no devices</source>
+        <translation type="unfinished">%1：无设备</translation>
+    </message>
+    <message>
+        <source>Switch to Welcome Menu</source>
+        <translation type="unfinished">切换到欢迎菜单</translation>
+    </message>
+    <message>
+        <source>Switch to Connected Devices</source>
+        <translation type="unfinished">切换到已连接设备</translation>
+    </message>
+    <message>
+        <source>Unmount Failed</source>
+        <translation type="unfinished">卸载失败</translation>
+    </message>
+    <message>
+        <source>Failed to unmount iFuse at %1. Please try again.</source>
+        <translation type="unfinished">无法卸载 %1 处的 iFuse。请重试。</translation>
+    </message>
+    <message>
+        <source>New portable version downloaded, app location will be shown after this message</source>
+        <translation type="unfinished">已下载新的便携版，本提示之后将显示应用所在位置</translation>
+    </message>
+    <message>
+        <source>The application will now quit to install the update.</source>
+        <translation type="unfinished">应用程序将立即退出以安装更新。</translation>
+    </message>
+    <message>
+        <source>New portable version downloaded</source>
+        <translation type="unfinished">已下载新的便携版</translation>
+    </message>
+    <message>
+        <source>Do you want to install the downloaded update now?</source>
+        <translation type="unfinished">是否立即安装已下载的更新？</translation>
+    </message>
+    <message>
+        <source>The application will now quit and open .dmg file downloaded to &quot;Downloads&quot; from there you can drag it to Applications to install.</source>
+        <translation type="unfinished">应用程序将退出并打开下载到“下载”文件夹中的 .dmg 文件，您可将其拖入“应用程序”文件夹完成安装。</translation>
+    </message>
+    <message>
+        <source>Update downloaded would you like to quit and install the update?</source>
+        <translation type="unfinished">已下载更新，是否退出并安装？</translation>
+    </message>
+    <message>
+        <source>AppImages we ship are not updateable. New version is downloaded to &quot;Downloads&quot;. You can start using the new version by launching it from there. You can delete this AppImage version if you like.</source>
+        <translation type="unfinished">我们提供的 AppImage 不支持自动更新。新版本已下载至“下载”文件夹，可从那里启动新版本使用。您可以删除当前的 AppImage 版本。</translation>
+    </message>
+    <message>
+        <source>Update downloaded would you like to quit and open the new version?</source>
+        <translation type="unfinished">已下载更新，是否退出并打开新版本？</translation>
+    </message>
+    <message>
+        <source>You seem to have installed %1 using a package manager. Please use %2 to update it.</source>
+        <translation type="unfinished">您似乎是通过包管理器安装了 %1。请使用 %2 进行更新。</translation>
+    </message>
+    <message>
+        <source>&amp;Help</source>
+        <translation type="unfinished">帮助(&amp;H)</translation>
+    </message>
+    <message>
+        <source>&amp;About %1</source>
+        <translation type="unfinished">关于 %1(&amp;A)</translation>
+    </message>
+    <message numerus="yes">
+        <source>%1: %n device(s) connected</source>
+        <translation type="unfinished">
+            <numerusform>%1：已连接 %n 台设备</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>About %1</source>
+        <translation type="unfinished">关于 %1</translation>
+    </message>
+    <message>
+        <source>A free, open-source, and cross-platform iDevice management tool.</source>
+        <translation type="unfinished">一款免费、开源、跨平台的 iDevice 管理工具。</translation>
+    </message>
+    <message>
+        <source>Transfers in Progress</source>
+        <translation type="unfinished">正在传输</translation>
+    </message>
+    <message>
+        <source>There are import/export operations in progress.
+Do you really want to quit? This will cancel them.</source>
+        <translation type="unfinished">有正在进行的导入/导出操作。
+确定要退出吗？这会取消这些操作。</translation>
+    </message>
+</context>
+<context>
+    <name>SettingsManager</name>
+    <message>
+        <source>Settings - iDescriptor</source>
+        <translation type="unfinished">设置 - iDescriptor</translation>
+    </message>
+</context>
+<context>
+    <name>SettingsWidget</name>
+    <message>
+        <source>Settings</source>
+        <translation type="unfinished">设置</translation>
+    </message>
+    <message>
+        <source>General</source>
+        <translation type="unfinished">通用</translation>
+    </message>
+    <message>
+        <source>Download Path:</source>
+        <translation type="unfinished">下载路径：</translation>
+    </message>
+    <message>
+        <source>Browse...</source>
+        <translation type="unfinished">浏览...</translation>
+    </message>
+    <message>
+        <source>Wireless File Server Port:</source>
+        <translation type="unfinished">无线文件服务器端口：</translation>
+    </message>
+    <message>
+        <source>The starting port for the wireless file server. If this port is unavailable, it will try the next 10 ports.</source>
+        <translation type="unfinished">无线文件服务器的起始端口。如果该端口不可用，将尝试随后的 10 个端口。</translation>
+    </message>
+    <message>
+        <source>Unmount iFuse drives on exit</source>
+        <translation type="unfinished">退出时卸载 iFuse 驱动器</translation>
+    </message>
+    <message>
+        <source>Automatically check for updates</source>
+        <translation type="unfinished">自动检查更新</translation>
+    </message>
+    <message>
+        <source>Automatically enable Wi-Fi connections</source>
+        <translation type="unfinished">自动启用 Wi-Fi 连接</translation>
+    </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished">主题：</translation>
+    </message>
+    <message>
+        <source>System Default</source>
+        <translation type="unfinished">系统默认</translation>
+    </message>
+    <message>
+        <source>Language:</source>
+        <translation type="unfinished">语言：</translation>
+    </message>
+    <message>
+        <source>Backdrop Type:</source>
+        <translation type="unfinished">背景效果类型：</translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <comment>Backdrop type</comment>
+        <translation type="unfinished">自动</translation>
+    </message>
+    <message>
+        <source>Mica</source>
+        <translation type="unfinished">Mica</translation>
+    </message>
+    <message>
+        <source>Mica Alt</source>
+        <translation type="unfinished">Mica Alt</translation>
+    </message>
+    <message>
+        <source>Acrylic</source>
+        <translation type="unfinished">Acrylic</translation>
+    </message>
+    <message>
+        <source>Disable Mica effects (also disables WinUI styles)</source>
+        <translation type="unfinished">禁用 Mica 效果（同时禁用 WinUI 样式）</translation>
+    </message>
+    <message>
+        <source>Device Connection</source>
+        <translation type="unfinished">设备连接</translation>
+    </message>
+    <message>
+        <source>Auto-raise main window on device connection</source>
+        <translation type="unfinished">设备连接时自动置顶主窗口</translation>
+    </message>
+    <message>
+        <source>Switch to newly connected device</source>
+        <translation type="unfinished">切换到新连接的设备</translation>
+    </message>
+    <message>
+        <source>Automatically connect to wireless devices</source>
+        <translation type="unfinished">自动连接无线设备</translation>
+    </message>
+    <message>
+        <source>Connection Timeout:</source>
+        <translation type="unfinished">连接超时：</translation>
+    </message>
+    <message>
+        <source> seconds</source>
+        <translation type="unfinished"> 秒</translation>
+    </message>
+    <message>
+        <source>Security</source>
+        <translation type="unfinished">安全</translation>
+    </message>
+    <message>
+        <source>Use unsecure backend for app store (ipatool)</source>
+        <translation type="unfinished">为 App Store 使用不安全的后端 (ipatool)</translation>
+    </message>
+    <message>
+        <source>Enabling this may put your Apple account at risk but you don&apos;t have to deal with Apple keychain.</source>
+        <translation type="unfinished">启用此选项可能会使您的 Apple 账户面临风险，但您无需处理 Apple 钥匙串。</translation>
+    </message>
+    <message>
+        <source>Jailbroken</source>
+        <translation type="unfinished">越狱</translation>
+    </message>
+    <message>
+        <source>Default Jailbroken Root Password:</source>
+        <translation type="unfinished">越狱设备的默认 root 密码：</translation>
+    </message>
+    <message>
+        <source>Default password used for SSH root authentication on jailbroken devices: Default is &apos;alpine&apos;.</source>
+        <translation type="unfinished">用于越狱设备 SSH root 身份认证的默认密码：默认值为 “alpine”。</translation>
+    </message>
+    <message>
+        <source>AirPlay</source>
+        <translation type="unfinished">AirPlay</translation>
+    </message>
+    <message>
+        <source>Fps:</source>
+        <translation type="unfinished">帧率：</translation>
+    </message>
+    <message>
+        <source>Set the fps for AirPlay. Go with 30 fps if have an older device.</source>
+        <translation type="unfinished">设置 AirPlay 的帧率。如果设备较旧，建议选择 30 fps。</translation>
+    </message>
+    <message>
+        <source>Allow New Connections to Take Over</source>
+        <translation type="unfinished">允许新连接接管</translation>
+    </message>
+    <message>
+        <source>Use legacy ports</source>
+        <translation type="unfinished">使用旧版端口</translation>
+    </message>
+    <message>
+        <source>Use legacy ports, refer to AIRPLAY.md for more information.</source>
+        <translation type="unfinished">使用旧版端口，详细信息请参阅 AIRPLAY.md。</translation>
+    </message>
+    <message>
+        <source>Show V4L2 Button on AirPlay Widget</source>
+        <translation type="unfinished">在 AirPlay 控件上显示 V4L2 按钮</translation>
+    </message>
+    <message>
+        <source>Miscellaneous</source>
+        <translation type="unfinished">其他</translation>
+    </message>
+    <message>
+        <source>Icon Size Base Multiplier:</source>
+        <translation type="unfinished">图标尺寸基础倍数：</translation>
+    </message>
+    <message>
+        <source>Adjust the base multiplier for icon sizes. This affects how large icons appear throughout the application. Requires restart to take effect.</source>
+        <translation type="unfinished">调整图标尺寸的基础倍数。该设置会影响整个应用中图标的显示大小，需重启后生效。</translation>
+    </message>
+    <message>
+        <source>iDescriptor v%1
+A free, open-source, and cross-platform iDevice management tool.
+© 2026 See AUTHORS for details. Licensed under AGPLv3.</source>
+        <translation type="unfinished">iDescriptor v%1
+一款免费、开源、跨平台的 iDevice 管理工具。
+© 2026 详细信息请参阅 AUTHORS。基于 AGPLv3 许可发布。</translation>
+    </message>
+    <message>
+        <source>Check for Updates</source>
+        <translation type="unfinished">检查更新</translation>
+    </message>
+    <message>
+        <source>Reset Settings</source>
+        <translation type="unfinished">重置设置</translation>
+    </message>
+    <message>
+        <source>Apply</source>
+        <translation type="unfinished">应用</translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished">警告</translation>
+    </message>
+    <message>
+        <source>Enabling this will not encrypt your Apple account which is a security risk. Are you sure you want to enable this?</source>
+        <translation type="unfinished">启用此选项将不会加密您的 Apple 账户，存在安全风险。确定要启用吗？</translation>
+    </message>
+    <message>
+        <source>Select Download Directory</source>
+        <translation type="unfinished">选择下载目录</translation>
+    </message>
+    <message>
+        <source>Checking...</source>
+        <translation type="unfinished">检查中...</translation>
+    </message>
+    <message>
+        <source>No Updates</source>
+        <translation type="unfinished">没有更新</translation>
+    </message>
+    <message>
+        <source>You are using the latest version of iDescriptor.</source>
+        <translation type="unfinished">您正在使用最新版本的 iDescriptor。</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to reset all settings to their default values?</source>
+        <translation type="unfinished">确定要将所有设置恢复为默认值吗？</translation>
+    </message>
+    <message>
+        <source>Settings applied. Please restart the application for changes to take effect.</source>
+        <translation type="unfinished">设置已应用。请重启应用程序以使更改生效。</translation>
+    </message>
+    <message>
+        <source>Settings applied.</source>
+        <translation type="unfinished">设置已应用。</translation>
+    </message>
+</context>
+<context>
+    <name>TranslationManager</name>
+    <message>
+        <source>System</source>
+        <translation type="unfinished">系统</translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <source>Settings Reset</source>
+        <translation type="unfinished">重置设置</translation>
+    </message>
+    <message>
+        <source>All application settings have been reset to their default values.</source>
+        <translation type="unfinished">所有应用程序设置已恢复为默认值。</translation>
+    </message>
+</context>
 </TS>


### PR DESCRIPTION
## Summary

This PR introduces Qt Linguist based internationalization (i18n) for iDescriptor and ships an initial set of translations for English (source), Japanese, and Simplified Chinese. Language can be switched at runtime from the Settings dialog without restarting the application.

## Motivation

iDescriptor's UI strings are currently hard-coded in English. This PR lays down the i18n foundation so that subsequent PRs can incrementally wrap the remaining widgets without re-litigating the build, runtime, and settings plumbing each time.

## What's included

### Build system
- `find_package(Qt6 ... LinguistTools)` added.
- `qt_add_translations(iDescriptor TS_FILES ... RESOURCE_PREFIX "/i18n" LUPDATE_OPTIONS -no-obsolete -locations relative)` so compiled `.qm` files are embedded as Qt resources under `:/i18n/`. Guarded under `if(QT_VERSION_MAJOR EQUAL 6)` to match the existing `qt_finalize_executable` pattern.
- No CI changes required — `jurplel/install-qt-action` already provides `lupdate`/`lrelease`.

### Runtime
- New `TranslationManager` singleton (`src/translationmanager.{h,cpp}`):
  - `initFromSettings()` is called from `main()` immediately after `QApplication` construction and resolves the active locale in the order: persisted preference → `QLocale::system()` → `en` source.
  - `setLocale(code)` swaps the installed `QTranslator` instances (app + Qt standard) and persists the choice. An empty string means "follow the host system locale".
  - Relies on Qt's `QEvent::LanguageChange` propagation to refresh widgets without a restart.
- `src/i18n_helper.h` provides a thin `QCoreApplication::translate` wrapper namespace (`idescriptor::i18n::tr`). It exists as a stable seam for future integration with the project's Rust modules through cxx-qt; no C ABI is exposed in this PR.

### Settings
- `SettingsManager` gains a `language` key with getter/setter and a `languageChanged(QString)` signal. `resetToDefaults()` resets it to the system-following sentinel.
- `SettingsWidget` is refactored: UI construction stays in the constructor, but every translatable string moves into a new `retranslateUi()` method. `changeEvent(QEvent::LanguageChange)` triggers re-translation. A new "Language:" combo box is added under "Theme:" with options derived from `TranslationManager::availableLocaleCodes()`. The Apply button persists the locale via `TranslationManager::setLocale()`.
- Existing combo boxes (`Theme`, `Backdrop Type`) now use `addItem(QString(), userData)` so the persisted value remains locale-independent across language changes.

### MainWindow
- `&Help` menu added on every platform with an `&About iDescriptor` action. `QAction::AboutRole` is set so macOS continues to surface About in the Application Menu while Linux/Windows display it under Help, preserving the existing macOS UX.
- `changeEvent(QEvent::LanguageChange)` triggers `retranslateUi()`, which refreshes the menu, tab labels, status bar, and update-related dialog text.
- The status bar now uses `tr("%1: %n device(s) connected", "", count).arg(qApp->applicationName())` so plural forms can be expressed per locale instead of relying on English-only " device" / " devices" branching.

### Translations
- `translations/idescriptor_en.ts` — source language; the empty translation table is intentional (Qt returns the source string when no translation is available).
- `translations/idescriptor_ja.ts` — initial Japanese translation, fully populated.
- `translations/idescriptor_zh_CN.ts` — Simplified Chinese baseline. Every entry currently carries `type="unfinished"`, so Qt Linguist surfaces them as needing review.

Initial translations: ja by author, zh_CN machine-translated baseline. Improvements welcome.

### Documentation
- `docs/CONTRIBUTING_TRANSLATIONS.md` — short, English-only guide explaining how to add a new language, improve an existing one, regenerate `.ts` files after source changes, and the conventions used (placeholders, mnemonics, proper-noun handling).

`README.md` is intentionally untouched.

## Scope

This is a foundation PR. Only the strings exposed by `Settings`, the new `Help`/`About` menu, and the parts of `MainWindow` directly tied to the menu/status bar are wrapped with `tr()`. The rest of the application continues to display English regardless of the selected locale until subsequent PRs wrap each widget. The infrastructure is in place so those follow-ups can focus purely on `tr()` wrapping plus a per-widget `retranslateUi()` split.

## Out of scope

- The Rust modules (cxx-qt) are not localised in this PR. `i18n_helper.h` provides the seam for a future PR to bridge Rust strings into the same `.ts`/`.qm` pipeline.
- Right-to-left languages.
- Adding any new languages beyond the three listed above. Adding `xx_YY` is a one-line addition to `TS_FILES` plus a new `.ts` file; contributions welcome.

## Verification

Local manual checks (recommended for reviewers):

- [ ] Build the project on Linux/macOS/Windows (CI handles this automatically through the existing workflows).
- [ ] Launch the application, open Settings, and confirm the "Language:" combo appears under "Theme:".
- [ ] Pick "日本語" and click Apply: Settings, the Help menu, the About dialog, and the MainWindow status bar update without a restart.
- [ ] Pick "简体中文" and click Apply: text switches to the Simplified Chinese baseline (entries are intentionally marked unfinished and may benefit from native review).
- [ ] Pick "System" and click Apply: the locale follows the host system.
- [ ] Restart the application and confirm the previously selected language is preserved.
- [ ] On macOS, confirm the About item still appears in the Application Menu (`QAction::AboutRole` effect).

## Follow-up PRs

Planned, one domain per PR to keep diffs reviewable:

1. Device sidebar / device detail widgets.
2. Apps / Files / Media widgets.
3. AirPlay / VirtualLocation.
4. Dialogs (MediaPreview, JailbrokenLogin, ad-hoc QMessageBox text).
5. Rust-side string integration via the `i18n_helper.h` seam.

Each follow-up will only touch its target widgets plus the relevant `.ts` entries.