### PR TITLE
Macos qt import export file dialog fix

### DIFF
--- a/src/afcexplorerwidget.cpp
+++ b/src/afcexplorerwidget.cpp
@@ -349,7 +349,8 @@ void AfcExplorerWidget::onExportClicked()
 void AfcExplorerWidget::handleExport(QList<QListWidgetItem *> filesToExport)
 {
     QString dir =
-        QFileDialog::getExistingDirectory(this, "Select Export Directory");
+        QFileDialog::getExistingDirectory(this, "Select Export Directory", QString(),
+                                         QFileDialog::ShowDirsOnly | QFileDialog::DontResolveSymlinks | QFileDialog::DontUseNativeDialog);
     if (dir.isEmpty())
         return;
 
@@ -426,7 +427,8 @@ void AfcExplorerWidget::exportAndOpenSelectedFile(QListWidgetItem *item,
 
 void AfcExplorerWidget::onImportClicked()
 {
-    QStringList fileNames = QFileDialog::getOpenFileNames(this, "Import Files");
+    QStringList fileNames = QFileDialog::getOpenFileNames(this, "Import Files", QString(),
+                                                         "All Files (*)", nullptr, QFileDialog::DontUseNativeDialog);
     if (fileNames.isEmpty())
         return;
 

--- a/src/gallerywidget.cpp
+++ b/src/gallerywidget.cpp
@@ -367,7 +367,7 @@ QString GalleryWidget::selectExportDirectory()
 
     QString selectedDir = QFileDialog::getExistingDirectory(
         this, "Select Export Directory", defaultDir,
-        QFileDialog::ShowDirsOnly | QFileDialog::DontResolveSymlinks);
+        QFileDialog::ShowDirsOnly | QFileDialog::DontResolveSymlinks | QFileDialog::DontUseNativeDialog);
 
     return selectedDir;
 }
@@ -716,10 +716,14 @@ void GalleryWidget::onPhotoContextMenu(const QPoint &pos)
 
 void GalleryWidget::handleImport()
 {
+    QString defaultDir = QStandardPaths::writableLocation(QStandardPaths::PicturesLocation);
+    
     QStringList filePaths = QFileDialog::getOpenFileNames(
         this, "Select Photos to Import",
-        QStandardPaths::writableLocation(QStandardPaths::PicturesLocation),
-        "Images (*.jpg *.jpeg *.png *.heic);;All Files (*)");
+        defaultDir,
+        "Images (*.jpg *.jpeg *.png *.heic);;All Files (*)",
+        nullptr,
+        QFileDialog::DontUseNativeDialog);
 
     if (filePaths.isEmpty()) {
         return;


### PR DESCRIPTION
Fix file dialogs not appearing on macOS

macOS was blocking native Qt file dialogs from appearing in Gallery and Files screens. Added QFileDialog::DontUseNativeDialog flag to force Qt's cross-platform dialogs instead.

Changes:
- Gallery: Fixed import photos and export directory dialogs
- Files: Fixed import files and export directory dialogs