### PR TITLE
fix(packaging): harden windows portable deploy + add Qt mingw fixups

### DIFF
--- a/packaging/windows/portable/deploy.sh
+++ b/packaging/windows/portable/deploy.sh
@@ -7,6 +7,10 @@ set -euo pipefail
 #cd target/deploy
 #cp ../release/idescriptor.exe ./
 #bash ../../packaging/windows/portable/deploy.sh --executable="./idescriptor.exe" --qt-bin-path="C:\Qt\6.9.3\mingw_64\bin" --project-source-dir="../../" --qml-source-dir="/c/Users/uncore/Desktop/iDescriptor/src/ui"
+#
+#Optional:
+#  --strict-dlls                 abort if any DLL pattern matches nothing (default: warn)
+#  --qt-fixups-dir=<dir>         overlay locally rebuilt Qt modules (see ../qt-mingw-fixups/README.md)
 
 
 # Parse arguments
@@ -16,6 +20,8 @@ QT_BIN_PATH=""
 MSYS2_BIN_PATH="/c/msys64/mingw64/bin"  # default
 QML_SOURCE_DIR=""
 PROJECT_SOURCE_DIR=""
+QT_FIXUPS_DIR=""      # optional: overlay locally rebuilt Qt module DLLs (see ../qt-mingw-fixups/README.md)
+STRICT_DLLS=0         # 1 = abort when a pattern matches nothing (old behaviour)
 
 for arg in "$@"; do
     case $arg in
@@ -25,6 +31,8 @@ for arg in "$@"; do
         --msys2-bin-path=*) MSYS2_BIN_PATH="${arg#*=}" ;;
         --qml-source-dir=*) QML_SOURCE_DIR="${arg#*=}" ;;
         --project-source-dir=*) PROJECT_SOURCE_DIR="${arg#*=}" ;;
+        --qt-fixups-dir=*) QT_FIXUPS_DIR="${arg#*=}" ;;
+        --strict-dlls) STRICT_DLLS=1 ;;
         *) echo "Unknown argument: $arg"; exit 1 ;;
     esac
 done
@@ -117,6 +125,10 @@ done
 
 echo "Successfully copied ${COPIED_PLUGIN_COUNT} requested GStreamer plugins"
 
+# NOTE: entries may contain globs. MSYS2 bumps DLL sonames on routine updates
+# (avcodec-61 -> avcodec-63 etc.), so anything version-suffixed should be a
+# pattern like "avcodec-*.dll" instead of a hard pin that silently stops
+# matching after an update.
 ADDITIONAL_DLLS=(
     "libgcc_s_seh-1.dll"
     "libstdc++-6.dll"
@@ -125,19 +137,19 @@ ADDITIONAL_DLLS=(
     "libgstbase-1.0-0.dll"
     "libgstcodecparsers-1.0-0.dll"
     "libgstcodecs-1.0-0.dll"
-    "libgobject-2.0-0.dll"
-    "libglib-2.0-0.dll"
+    "libgobject-2.0-*.dll"
+    "libglib-2.0-*.dll"
     "libintl-8.dll"
     "libiconv-2.dll"
     "libfdk-aac-2.dll"
     "libfaad-2.dll"
-    "avcodec-61.dll"
-    "avformat-61.dll"
-    "avutil-59.dll"
-    "swresample-5.dll"
-    "swscale-8.dll"
+    "avcodec-*.dll"
+    "avformat-*.dll"
+    "avutil-*.dll"
+    "swresample-*.dll"
+    "swscale-*.dll"
     # "avfilter-11.dll"
-    "avfilter-10.dll"
+    "avfilter-*.dll"
     "libopenal-1.dll"
     "libgstaudio-1.0-0.dll"
     "libgstvideo-1.0-0.dll"
@@ -145,7 +157,7 @@ ADDITIONAL_DLLS=(
     "libgstpbutils-1.0-0.dll"
     "libgsttag-1.0-0.dll"
     # "libgstlibav.dll"
-    "libass-9.dll"
+    "libass-*.dll"
     "libfontconfig-1.dll"
     "libharfbuzz-0.dll"
     "libexpat-1.dll"
@@ -153,7 +165,7 @@ ADDITIONAL_DLLS=(
     "libpng16-16.dll"
     "libgraphite2.dll"
     "libfribidi-0.dll"
-    "libunibreak-6.dll"
+    "libunibreak-*.dll"
     "liblcms2-2.dll"
     "libvpl-2.dll"
     "libzimg-2.dll"
@@ -162,11 +174,10 @@ ADDITIONAL_DLLS=(
     "vulkan-1.dll"
     "libvidstab.dll"
     "libgomp-1.dll"
-    "postproc-58.dll"
-    "libplacebo-351.dll"
+    "postproc-*.dll"
+    "libplacebo-*.dll"
     "libspirv-cross-c-shared.dll"
     "libva.dll"
-    # "libxml2-16.dll"
     "libva_win32.dll"
     "libpcre2-8-0.dll"
     "libffi-8.dll"
@@ -174,16 +185,18 @@ ADDITIONAL_DLLS=(
     "libhwy.dll"
     "libmp3lame-0.dll"
     "librsvg-2-2.dll"
-    "libwebp-7.dll"
+    "libwebp-*.dll"
     "libthai-0.dll"
     "libjxl.dll"
     "libdatrie-1.dll"
-    "libwebpmux-3.dll"
-    "libx264-164.dll"
+    "libwebpmux-*.dll"
+    "libx264-*.dll"
     "libtasn1-6.dll"
     "libgsm.dll"
     "libcairo-gobject-2.dll"
     "libvorbis-0.dll"
+    # libvorbisenc is NOT matched by libvorbis-* (different basename!)
+    "libvorbisenc-*.dll"
     "libgio-2.0-0.dll"
     "libgmp-10.dll"
     "libmodplug-1.dll"
@@ -197,56 +210,57 @@ ADDITIONAL_DLLS=(
     "libjxl_threads.dll"
     "libgnutls-30.dll"
     "libp11-kit-0.dll"
-    "libopencore-amrwb-0.dll"
-    "libtheoradec-2.dll"
+    "libopencore-amrwb-*.dll"
+    "libtheoradec-*.dll"
     "libvpx-1.dll"
     "libgme.dll"
-    "libhogweed-6.dll"
-    "liblc3-1.dll"
+    "libhogweed-*.dll"
+    "liblc3-*.dll"
     "libpango-1.0-0.dll"
     "xvidcore.dll"
-    "libopencore-amrnb-0.dll"
+    "libopencore-amrnb-*.dll"
     "libtiff-6.dll"
-    "libxml2-2.dll"
+    # mingw64 currently ships libxml2-16.dll; older pins (libxml2-2) went stale
+    "libxml2-*.dll"
     "libjbig-0.dll"
     "libLerc.dll"
     "libjxl_cms.dll"
     "libgdk_pixbuf-2.0-0.dll"
-    "libvorbisenc-2.dll"
     "libsoxr.dll"
     "librtmp-1.dll"
     "libcairo-2.dll"
     "libdeflate.dll"
     "libpangocairo-1.0-0.dll"
     "libpangoft2-1.0-0.dll"
-    "libtheoraenc-2.dll"
-    "libbluray-2.dll"
-    "libnettle-8.dll"
-    "libunistring-5.dll"
-    "libidn2-0.dll"
+    "libtheoraenc-*.dll"
+    "libbluray-*.dll"
+    "libnettle-*.dll"
+    "libunistring-*.dll"
+    "libidn2-*.dll"
     "libssh.dll"
-    "libdav1d-7.dll"
+    "libdav1d-*.dll"
     "liblzma-5.dll"
-    "libopenjp2-7.dll"
+    # openjpeg was renamed to openjph in newer MSYS2; match either
+    "libopenjp2-*.dll"
+    "libopenjph-*.dll"
     "libzstd.dll"
-    "libSvtAv1Enc-3.dll"
+    "libSvtAv1Enc-*.dll"
     "libbrotlicommon.dll"
     "libjpeg-8.dll"
     "libb2-1.dll"
     "libarchive-13.dll"
     "libheif.dll"
-    "libopenh264-7.dll"
-    "libopenjph-0.21.dll"
+    "libopenh264-*.dll"
     "libcrypto-3-x64.dll"
     "zlib1.dll"
     "libbrotlienc.dll"
-    "libkvazaar-7.dll"
+    "libkvazaar-*.dll"
     "liblz4.dll"
     "librav1e.dll"
     "libaom.dll"
     "libbrotlidec.dll"
-    "libsharpyuv-0.dll"
-    "libx265-215.dll"
+    "libsharpyuv-*.dll"
+    "libx265-*.dll"
     "libcryptopp.dll"
     "libde265-0.dll"
     "libbz2-1.dll"
@@ -262,16 +276,27 @@ ADDITIONAL_DLLS=(
 )
 
 echo "Copying additional MinGW runtime DLLs from MSYS2..."
-for DLL_NAME in "${ADDITIONAL_DLLS[@]}"; do
-    DLL_PATH="${MSYS2_BIN_PATH}/${DLL_NAME}"
-    if [ -f "${DLL_PATH}" ]; then
-        echo "Copying additional DLL: ${DLL_NAME}"
-        cp "${DLL_PATH}" "${OUTPUT_DIR}/"
+shopt -s nullglob
+UNMATCHED_PATTERNS=0
+for DLL_PATTERN in "${ADDITIONAL_DLLS[@]}"; do
+    MATCHES=("${MSYS2_BIN_PATH}/${DLL_PATTERN}")
+    if [ ${#MATCHES[@]} -gt 0 ]; then
+        for MATCHED_PATH in "${MATCHES[@]}"; do
+            echo "Copying additional DLL: $(basename "${MATCHED_PATH}")"
+            cp "${MATCHED_PATH}" "${OUTPUT_DIR}/"
+        done
     else
-        echo "Error: Additional DLL not found: ${DLL_NAME} (searched ${MSYS2_BIN_PATH})"
-        exit 1
+        UNMATCHED_PATTERNS=$((UNMATCHED_PATTERNS + 1))
+        echo "WARN: no DLL matched pattern '${DLL_PATTERN}' (searched ${MSYS2_BIN_PATH})"
+        if [ "${STRICT_DLLS}" = 1 ]; then
+            echo "Error: strict mode enabled (--strict-dlls), aborting."
+            exit 1
+        fi
     fi
 done
+if [ "${UNMATCHED_PATTERNS}" -gt 0 ]; then
+    echo "NOTE: ${UNMATCHED_PATTERNS} pattern(s) matched nothing - usually just an MSYS2 package rename; check the WARNs above."
+fi
 
 echo "Copying GStreamer helper executables..."
 GST_LIBEXEC_PATH="${MSYS2_BIN_PATH}/../libexec/gstreamer-1.0"
@@ -288,5 +313,41 @@ cp "${PROJECT_SOURCE_DIR}/install-win-fsp.silent.bat" "${OUTPUT_DIR}/"
 
 echo "Copying winfsp-x64.dll"
 cp "/c/Program Files (x86)/WinFsp/bin/winfsp-x64.dll" "${OUTPUT_DIR}/"
+
+# ---------------------------------------------------------------------------
+# Optional: overlay locally rebuilt Qt module DLLs (--qt-fixups-dir=<dir>).
+#
+# The official Qt mingw binaries are built with an older GCC than current
+# MSYS2 ships. Two launch-breaking mismatches have been observed with
+# Qt 6.9.3 mingw_64 + MSYS2 MinGW64 (root causes + rebuild instructions in
+# ../qt-mingw-fixups/README.md):
+#   1) qml/Qt5Compat/GraphicalEffects/private/qtgraphicaleffectsprivateplugin.dll
+#      imports adjustor thunks (_ZThn16_N10QQuickItem*) that its own
+#      Qt6Quick.dll does not export;
+#   2) Qt6ShaderTools.dll / Qt6Multimedia.dll import __emutls_v.* symbols
+#      that newer libstdc++-6.dll removed; they fail with PROC_NOT_FOUND,
+#      taking every plugin that links them down with them.
+# Layout expected under the fixups dir:
+#   <dir>/<module>/bin/*.dll                     -> ${OUTPUT_DIR}/
+#   <dir>/qtmultimedia/plugins/multimedia/*.dll  -> ${OUTPUT_DIR}/plugins/multimedia/
+# ---------------------------------------------------------------------------
+if [ -n "${QT_FIXUPS_DIR}" ]; then
+    if [ ! -d "${QT_FIXUPS_DIR}" ]; then
+        echo "WARN: --qt-fixups-dir given but directory not found: ${QT_FIXUPS_DIR}"
+    else
+        shopt -s nullglob
+        for MOD_DIR in "${QT_FIXUPS_DIR}"/*/; do
+            for FIXUP_DLL in "${MOD_DIR}"bin/*.dll; do
+                cp -f "${FIXUP_DLL}" "${OUTPUT_DIR}/"
+                echo "Applied qt-fixup: $(basename "${FIXUP_DLL}")"
+            done
+            for FIXUP_PLUGIN in "${MOD_DIR}"plugins/multimedia/*.dll; do
+                mkdir -p "${OUTPUT_DIR}/plugins/multimedia"
+                cp -f "${FIXUP_PLUGIN}" "${OUTPUT_DIR}/plugins/multimedia/"
+                echo "Applied qt-fixup: plugins/multimedia/$(basename "${FIXUP_PLUGIN}")"
+            done
+        done
+    fi
+fi
 
 echo "=== Windows deployment completed ==="

--- a/packaging/windows/qt-mingw-fixups/README.md
+++ b/packaging/windows/qt-mingw-fixups/README.md
@@ -1,0 +1,92 @@
+# Qt mingw_64 + MSYS2 MinGW64 launch fixes
+
+The official Qt `win64_mingw` binaries (verified with 6.9.3) are built with an
+older GCC than current MSYS2 ships. If you build the app with MSYS2's MinGW64
+toolchain, the two runtimes cannot fully coexist, and three distinct
+launch-breaking mismatches have been observed. All are fixed the same way:
+rebuild the affected Qt module/plugin from matching-version source with your
+local toolchain and stamp the results over the deployed copies.
+
+Symptom in every case: the app starts but stays headless (no window), and the
+QML engine log shows plugins failing with
+"The specified procedure could not be found" — sometimes naming a plugin that
+is actually innocent (the real culprit is one of *its* dependencies).
+
+## Defect 1 — phantom thunk imports in GraphicalEffects private plugin
+
+`qml/Qt5Compat/GraphicalEffects/private/qtgraphicaleffectsprivateplugin.dll`
+imports two non-virtual adjustor thunks from Qt6Quick.dll:
+
+- `_ZThn16_N10QQuickItem10classBeginEv`
+- `_ZThn16_N10QQuickItem17componentCompleteEv`
+
+Qt6Quick.dll does not export them (verify at PE level: identical hashes
+between the installed copy and every deploy). Without them,
+`DropShadow` is unavailable → `AnimatedDialog`/`ClosingHandler` unavailable →
+Main.qml fails to load.
+
+**Fix:** `build-qtgraphicaleffects.sh` rebuilds the plugin and injects
+`qt5compat-shim/qtgraphicaleffects-thunks.cpp`, which defines the two thunks
+locally as byte-exact assembly (`subq $16,%rcx; jmp <real method>`), so the
+plugin satisfies its own imports at link time.
+
+## Defect 2 — emutls symbols removed from newer libstdc++
+
+Stock `Qt6ShaderTools.dll` and `Qt6Multimedia.dll` import from
+libstdc++-6.dll:
+
+- `__emutls_v._ZSt11__once_call`
+- `__emutls_v._ZSt15__once_callable`
+
+Old GCC's libstdc++ exported these; current MSYS2 GCC16 libstdc++ removed
+them. Any process where the new libstdc++ wins the name binding (which is
+unavoidable when your own exe is built with GCC16) fails to load these DLLs.
+Because the GraphicalEffects private plugin links ShaderTools directly, this
+defect masks itself as Defect 1 even after that fix is applied.
+
+**Fix:** `build-qtshadertools.sh` and `build-qtmultimedia.sh` rebuild those
+modules against the local runtime; the phantom imports disappear.
+
+> qtmultimedia gotcha: configure enables the `vulkan` feature on finding just
+> `vulkan-1.dll.a`, but `QRhiVulkanInitParams` is only declared under
+> `(QT_CONFIG(vulkan) && __has_include(<vulkan/vulkan.h>))` — install
+> `mingw-w64-x86_64-vulkan-headers` first and delete any stale build dir.
+
+## Defect 3 — no single C++ runtime serves both sides
+
+Do NOT "fix" the above by swapping the deployed libstdc++/libgcc/libwinpthread
+trio for Qt's older bundled copies: current MSYS2 dependency DLLs (ffmpeg,
+gnutls, gstreamer core, openal, libheif, ...) import symbols that only exist
+in the NEW trio (`clock_gettime64`, `nanosleep64`, `pthread_cond_timedwait64`,
+`std::__detail __wait_impl`, ...). Neither runtime satisfies the whole tree;
+the only consistent policy is to keep the new trio and rebuild any official
+Qt binary that still needs old-runtime symbols.
+
+## Usage
+
+```bash
+# 1) Download + extract the module sources you need, e.g.:
+#    https://download.qt.io/official_releases/qt/<ver>/<ver>.<patch>/submodules/qtshadertools-everywhere-src-<ver>.zip
+
+# 2) Build each fixup (source dir as argument; stages next to the script):
+./build-qtgraphicaleffects.sh /path/to/qt5compat-everywhere-src-6.9.3
+./build-qtshadertools.sh      /path/to/qtshadertools-everywhere-src-6.9.3
+./build-qtmultimedia.sh       /path/to/qtmultimedia-everywhere-src-6.9.3
+
+# 3) Point the portable deploy at the staging tree:
+bash ../portable/deploy.sh ... --qt-fixups-dir="$(pwd)/stage"
+```
+
+Environment overrides: `QT_BIN_PATH` (default `C:/Qt/6.9.3/mingw_64`),
+`MSYSTEM=MINGW64` assumed. Each script verifies its output (objdump) before
+staging, so a failed fix cannot silently ship.
+
+Staging layout consumed by `deploy.sh --qt-fixups-dir`:
+
+```
+stage/
+  qtgraphicaleffects/{qtgraphicaleffectsplugin.dll,private/qtgraphicaleffectsprivateplugin.dll}
+  qtshadertools/bin/Qt6ShaderTools.dll
+  qtmultimedia/bin/*.dll
+  qtmultimedia/plugins/multimedia/*.dll
+```

--- a/packaging/windows/qt-mingw-fixups/build-qtgraphicaleffects.sh
+++ b/packaging/windows/qt-mingw-fixups/build-qtgraphicaleffects.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# ============================================================================
+# Rebuilds Qt5Compat's GraphicalEffects QML plugin (DropShadow et al.) with
+# the local MSYS2 MinGW64 toolchain and injects local definitions for the two
+# adjustor thunks the official private plugin wrongly imports from
+# Qt6Quick.dll. See README.md (Defect 1) in this directory.
+#
+# Usage:
+#   ./build-qtgraphicaleffects.sh /path/to/qt5compat-everywhere-src-<ver>
+#
+# Env overrides:
+#   QT_BIN_PATH   (default C:/Qt/6.9.3/mingw_64)
+#   STAGE_DIR     (default <this dir>/stage)
+#
+# Output: $STAGE_DIR/qtgraphicaleffects/{qtgraphicaleffectsplugin.dll,
+#         private/qtgraphicaleffectsprivateplugin.dll}
+# ============================================================================
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+QT_BIN_PATH="${QT_BIN_PATH:-C:/Qt/6.9.3/mingw_64}"
+STAGE_DIR="${STAGE_DIR:-${SCRIPT_DIR}/stage}"
+SHIM_SRC="${SCRIPT_DIR}/qt5compat-shim/qtgraphicaleffects-thunks.cpp"
+
+SRC="${1:-}"
+[ -n "$SRC" ] || { echo "usage: $0 /path/to/qt5compat-everywhere-src-<ver>"; exit 1; }
+[ -d "$SRC" ] || { echo "FATAL: source not found: $SRC"; exit 1; }
+[ -f "$SHIM_SRC" ] || { echo "FATAL: shim missing: $SHIM_SRC"; exit 1; }
+
+export MSYSTEM=MINGW64
+export PATH="/mingw64/bin:${QT_BIN_PATH}/bin:$PATH"
+
+BUILD="$SRC/build-mingw-fixup"
+PRIVATE_DIR="$SRC/src/imports/graphicaleffects5/private"
+
+echo "=== injecting thunk shim (idempotent) ==="
+cp -f "$SHIM_SRC" "$PRIVATE_DIR/qtgraphicaleffects-thunks.cpp"
+if ! grep -q 'qtgraphicaleffects-thunks.cpp' "$PRIVATE_DIR/CMakeLists.txt"; then
+    {
+        echo ""
+        echo "# Windows mingw fixup (see packaging/windows/qt-mingw-fixups/README.md)"
+        echo "target_sources(qtgraphicaleffectsprivate PRIVATE qtgraphicaleffects-thunks.cpp)"
+    } >> "$PRIVATE_DIR/CMakeLists.txt"
+    echo "  patched private/CMakeLists.txt"
+else
+    echo "  already patched"
+fi
+
+echo "=== configuring qt5compat (Ninja, Release) ==="
+cmake -S "$SRC" -B "$BUILD" -G Ninja \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_PREFIX_PATH="$QT_BIN_PATH" \
+    -DCMAKE_INSTALL_PREFIX="$BUILD/install"
+
+echo "=== building ==="
+ninja -C "$BUILD"
+
+PUB="$(find "$BUILD" -name 'qtgraphicaleffectsplugin.dll' -type f | head -1)"
+PRIV="$(find "$BUILD" -path '*private*' -name 'qtgraphicaleffectsprivateplugin.dll' -type f | head -1)"
+[ -n "$PUB" ]  || { echo "FATAL: public plugin dll not found"; exit 1; }
+[ -n "$PRIV" ] || { echo "FATAL: private plugin dll not found"; exit 1; }
+
+mkdir -p "$STAGE_DIR/qtgraphicaleffects/private"
+cp -f "$PUB"  "$STAGE_DIR/qtgraphicaleffects/qtgraphicaleffectsplugin.dll"
+cp -f "$PRIV" "$STAGE_DIR/qtgraphicaleffects/private/qtgraphicaleffectsprivateplugin.dll"
+
+echo "=== verifying override plugin no longer imports the phantom thunks ==="
+if objdump -p "$STAGE_DIR/qtgraphicaleffects/private/qtgraphicaleffectsprivateplugin.dll" | grep -q '_ZThn16_N10QQuickItem'; then
+    echo "FATAL: rebuilt plugin STILL imports _ZThn16 thunks - shim did not link"
+    exit 1
+fi
+echo "OK: no _ZThn16 QQuickItem imports"
+
+echo "=== DONE OK: $STAGE_DIR/qtgraphicaleffects ==="

--- a/packaging/windows/qt-mingw-fixups/build-qtmultimedia.sh
+++ b/packaging/windows/qt-mingw-fixups/build-qtmultimedia.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# ============================================================================
+# Rebuilds Qt6Multimedia (+ built-with-us backend plugins) with the local
+# MSYS2 MinGW64 toolchain. The official mingw binary imports __emutls_v.*
+# symbols that newer libstdc++ removed -> PROC_NOT_FOUND at load time.
+# See README.md (Defect 2).
+#
+# FFmpeg and GStreamer backends are disabled on purpose so only the Windows
+# Media Foundation backend is produced; stock ffmpegmediaplugin/gstreamer
+# plugins that don't import the removed symbols can stay as deployed.
+#
+# PREREQ: install vulkan headers first, or compilation fails in
+# qvideowindow.cpp (QRhiVulkanInitParams is gated on __has_include):
+#   pacman -S --needed mingw-w64-x86_64-vulkan-headers
+#
+# Usage:
+#   ./build-qtmultimedia.sh /path/to/qtmultimedia-everywhere-src-<ver>
+#
+# Env overrides:
+#   QT_BIN_PATH   (default C:/Qt/6.9.3/mingw_64)
+#   STAGE_DIR     (default <this dir>/stage)
+#
+# Output: $STAGE_DIR/qtmultimedia/bin/*.dll
+#         $STAGE_DIR/qtmultimedia/plugins/multimedia/*.dll
+# ============================================================================
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+QT_BIN_PATH="${QT_BIN_PATH:-C:/Qt/6.9.3/mingw_64}"
+STAGE_DIR="${STAGE_DIR:-${SCRIPT_DIR}/stage}"
+
+SRC="${1:-}"
+[ -n "$SRC" ] || { echo "usage: $0 /path/to/qtmultimedia-everywhere-src-<ver>"; exit 1; }
+[ -d "$SRC" ] || { echo "FATAL: source not found: $SRC"; exit 1; }
+
+export MSYSTEM=MINGW64
+export PATH="/mingw64/bin:${QT_BIN_PATH}/bin:$PATH"
+
+BUILD="$SRC/build-mingw-fixup"
+
+echo "=== configuring qtmultimedia (Ninja, Release) ==="
+cmake -S "$SRC" -B "$BUILD" -G Ninja \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_PREFIX_PATH="$QT_BIN_PATH" \
+    -DCMAKE_INSTALL_PREFIX="$BUILD/install" \
+    -DFEATURE_ffmpeg=off \
+    -DFEATURE_gstreamer=off
+
+echo "=== building ==="
+ninja -C "$BUILD"
+
+mkdir -p "$STAGE_DIR/qtmultimedia/bin" "$STAGE_DIR/qtmultimedia/plugins/multimedia"
+
+found=0
+for d in "$BUILD"/bin/*.dll; do
+    [ -e "$d" ] || continue
+    cp -f "$d" "$STAGE_DIR/qtmultimedia/bin/"
+    echo "  staged bin/$(basename "$d")"
+    found=1
+done
+[ "$found" = 1 ] || { echo "FATAL: no module DLLs found under $BUILD/bin"; exit 1; }
+
+for p in "$BUILD"/plugins/multimedia/*.dll; do
+    [ -e "$p" ] || continue
+    cp -f "$p" "$STAGE_DIR/qtmultimedia/plugins/multimedia/"
+    echo "  staged plugins/multimedia/$(basename "$p")"
+done
+
+echo "=== verifying no legacy emutls imports remain ==="
+FAIL=0
+for d in "$STAGE_DIR"/qtmultimedia/bin/*.dll "$STAGE_DIR"/qtmultimedia/plugins/multimedia/*.dll; do
+    [ -e "$d" ] || continue
+    if objdump -p "$d" | grep -q '__emutls_v'; then
+        echo "FATAL: $d still imports __emutls_v.* symbols"; FAIL=1
+    fi
+done
+[ "$FAIL" = 0 ] || exit 1
+echo "OK: no __emutls_v.* imports"
+
+echo "=== DONE OK: $STAGE_DIR/qtmultimedia ==="

--- a/packaging/windows/qt-mingw-fixups/build-qtshadertools.sh
+++ b/packaging/windows/qt-mingw-fixups/build-qtshadertools.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# ============================================================================
+# Rebuilds Qt6ShaderTools.dll with the local MSYS2 MinGW64 toolchain.
+# The official mingw binary imports __emutls_v.* symbols that newer
+# libstdc++ removed -> PROC_NOT_FOUND at load time. See README.md (Defect 2).
+#
+# Usage:
+#   ./build-qtshadertools.sh /path/to/qtshadertools-everywhere-src-<ver>
+#
+# Env overrides:
+#   QT_BIN_PATH   (default C:/Qt/6.9.3/mingw_64)
+#   STAGE_DIR     (default <this dir>/stage)
+#
+# Output: $STAGE_DIR/qtshadertools/bin/Qt6ShaderTools.dll
+# ============================================================================
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+QT_BIN_PATH="${QT_BIN_PATH:-C:/Qt/6.9.3/mingw_64}"
+STAGE_DIR="${STAGE_DIR:-${SCRIPT_DIR}/stage}"
+
+SRC="${1:-}"
+[ -n "$SRC" ] || { echo "usage: $0 /path/to/qtshadertools-everywhere-src-<ver>"; exit 1; }
+[ -d "$SRC" ] || { echo "FATAL: source not found: $SRC"; exit 1; }
+
+export MSYSTEM=MINGW64
+export PATH="/mingw64/bin:${QT_BIN_PATH}/bin:$PATH"
+
+BUILD="$SRC/build-mingw-fixup"
+
+echo "=== configuring qtshadertools (Ninja, Release) ==="
+cmake -S "$SRC" -B "$BUILD" -G Ninja \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_PREFIX_PATH="$QT_BIN_PATH" \
+    -DCMAKE_INSTALL_PREFIX="$BUILD/install"
+
+echo "=== building ==="
+ninja -C "$BUILD" qtshadertools
+
+DLL="$(find "$BUILD" -name 'Qt6ShaderTools.dll' -type f | head -1)"
+[ -n "$DLL" ] || { echo "FATAL: Qt6ShaderTools.dll not found in build"; exit 1; }
+
+mkdir -p "$STAGE_DIR/qtshadertools/bin"
+cp -f "$DLL" "$STAGE_DIR/qtshadertools/bin/Qt6ShaderTools.dll"
+
+echo "=== verifying no legacy emutls imports remain ==="
+if objdump -p "$STAGE_DIR/qtshadertools/bin/Qt6ShaderTools.dll" | grep -q '__emutls_v'; then
+    echo "FATAL: rebuilt Qt6ShaderTools.dll still imports __emutls_v.* symbols"
+    exit 1
+fi
+echo "OK: no __emutls_v.* imports"
+
+echo "=== DONE OK: $STAGE_DIR/qtshadertools ==="

--- a/packaging/windows/qt-mingw-fixups/qt5compat-shim/qtgraphicaleffects-thunks.cpp
+++ b/packaging/windows/qt-mingw-fixups/qt5compat-shim/qtgraphicaleffects-thunks.cpp
@@ -1,0 +1,32 @@
+// ============================================================================
+// Local adjustor thunks for two symbols that Qt 6.9.3's OFFICIAL mingw
+// Qt6Quick.dll forgot to export but its own GraphicalEffects private plugin
+// imports (Qt packaging defect; see windows-env/scripts/
+// build-qtgraphicaleffects.sh for the full story).
+//
+// These are byte-exact replacements of the missing Itanium-ABI non-virtual
+// thunks: receive `this` = QQmlParserStatus subobject pointer, adjust
+// -0x10 to reach the QQuickItem base, then tail-jump to the real method
+// (which Qt6Quick.dll DOES export). Implemented in asm so semantics cannot
+// drift from the real thunks.
+//
+// Defining them inside the plugin satisfies its own imports at link time;
+// the phantom imports disappear from the built DLL.
+// ============================================================================
+
+#ifdef __MINGW32__
+asm(
+    ".text\n"
+    ".globl _ZThn16_N10QQuickItem10classBeginEv\n"
+    "_ZThn16_N10QQuickItem10classBeginEv:\n"
+    "   subq $16, %rcx\n"
+    "   jmp _ZN10QQuickItem10classBeginEv\n"
+
+    ".globl _ZThn16_N10QQuickItem17componentCompleteEv\n"
+    "_ZThn16_N10QQuickItem17componentCompleteEv:\n"
+    "   subq $16, %rcx\n"
+    "   jmp _ZN10QQuickItem17componentCompleteEv\n"
+);
+#else
+#error "This shim is only meant for the MinGW64 build of qtgraphicaleffectsprivate"
+#endif


### PR DESCRIPTION
## Summary

Hardens the Windows portable packaging against MSYS2 soname churn and documents/workarounds three launch-breaking mismatches between official Qt `win64_mingw` binaries and a current MSYS2 MinGW64 toolchain.

### deploy.sh changes

- **Glob-aware `ADDITIONAL_DLLS`:** MSYS2 bumps DLL sonames on routine updates (`avcodec-61→63`, `libnettle-8→9`, `libSvtAv1Enc-3→4`, …), so every version-suffixed entry is now a pattern (`avcodec-*.dll`). Hard pins silently stopped matching after updates and produced broken deploys.
- **Warn instead of abort:** unmatched patterns now WARN with an end-of-run summary; pass `--strict-dlls` to restore the old fail-fast behaviour.
- **Fixed stale/wrong pins:** `libxml2-2.dll` (mingw64 ships `libxml2-16.dll`), openjph rename coverage, and `libvorbisenc-*` which was never matched by the `libvorbis-*` prefix.
- **New optional `--qt-fixups-dir=<dir>`:** overlays locally rebuilt Qt module DLLs onto the deploy tree after windeployqt (`<dir>/<module>/bin/*.dll → root`, `qtmultimedia/plugins/multimedia/*.dll → plugins/multimedia`).

### qt-mingw-fixups/ (new)

Scripts + README covering three defects observed with Qt 6.9.3 mingw_64 + MSYS2 MinGW64 GCC16, all presenting as "app runs headless, QML plugins fail with PROC_NOT_FOUND":

1. `qtgraphicaleffectsprivateplugin.dll` imports `_ZThn16_N10QQuickItem*` adjustor thunks its own Qt6Quick.dll does not export → fixed by rebuilding the plugin with an injected shim defining those thunks locally.
2. Stock `Qt6ShaderTools.dll` / `Qt6Multimedia.dll` import `__emutls_v._ZSt11__once_call` / `__emutls_v._ZSt15__once_callable`, which newer libstdc++ removed → rebuilt from matching sources so they link the current runtime.
3. Why you cannot just ship Qt's older libstdc++/winpthread trio instead: current MSYS2 deps need new-only symbols (`clock_gettime64`, `pthread_cond_timedwait64`, `std::__detail __wait_impl`, …). Neither runtime serves the whole tree; the consistent policy is new trio + rebuild offending Qt modules.

Each build script self-verifies its output (objdump) before staging, so a failed fix cannot silently ship.

## Testing

Verified locally against Qt 6.9.3 mingw_64 + MSYS2 MinGW64 (GCC 16):

- Portable release deploy passes an import-graph completeness gate resolving only from the deploy dir (no missing DLLs/symbols).
- Deployed app launches standalone with a visible QML main window (previously headless).
- `bash -n` passes on all modified/added scripts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows deployment reliability when DLL versions or optional files differ.
  * Added optional strict validation for missing deployment files.
  * Added Qt runtime fixups for GraphicalEffects, ShaderTools, and Multimedia compatibility issues.

* **Documentation**
  * Added guidance for building, staging, configuring, and verifying the Qt Windows runtime fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->