### PR TITLE
fix(ui): preserve USB connection over wireless events (fixes #125)

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -1122,6 +1122,7 @@ async fn init_idescriptor_device<
 
     let device_services = DeviceServices {
         connection_id,
+        is_wireless,
         afc: Arc::new(Mutex::new(afc_client)),
         afc2,
         diag: Arc::new(Mutex::new(diag_relay)),

--- a/src/device_ctx.rs
+++ b/src/device_ctx.rs
@@ -67,6 +67,7 @@ impl iOSVersion {
 #[derive(Clone)]
 pub struct DeviceServices {
     pub connection_id: u64,
+    pub is_wireless: bool,
     pub afc: Arc<Mutex<AfcClient>>,
     pub afc2: Option<Arc<Mutex<AfcClient>>>,
     pub diag: Arc<Mutex<DiagnosticsRelayClient>>,
@@ -175,11 +176,17 @@ pub async fn insert_device(
 ) -> InsertDeviceResult {
     let udid = udid.into();
     let mut state = APP_DEVICE_STATE.lock().await;
-    if state
-        .get(&udid)
-        .is_some_and(|current| current.connection_id > services.connection_id)
-    {
-        return InsertDeviceResult::Rejected;
+    if let Some(current) = state.get(&udid) {
+        if current.connection_id > services.connection_id {
+            return InsertDeviceResult::Rejected;
+        }
+        if !current.is_wireless && services.is_wireless {
+            log::info!(
+                "Rejecting wireless connection {} for udid {} because USB connection {} is active",
+                services.connection_id, udid, current.connection_id
+            );
+            return InsertDeviceResult::Rejected;
+        }
     }
 
     if let Some(mut old) = state.insert(udid.clone(), services) {

--- a/src/ui/DeviceContext.qml
+++ b/src/ui/DeviceContext.qml
@@ -412,8 +412,10 @@ QtObject {
                             break
                         }
                     }
-                    if (skipWirelessReplacement)
+                    if (skipWirelessReplacement) {
+                        root.selectConnectedDevice(udid)
                         break
+                    }
 
                     const pendingDeviceWasVisible =
                         root.currentDestination === "pendingDevice"

--- a/src/ui/DeviceContext.qml
+++ b/src/ui/DeviceContext.qml
@@ -398,14 +398,22 @@ QtObject {
                     if (currentDevice && currentDevice.connectionId === addedConnectionId)
                         break
 
+                    let skipWirelessReplacement = false
                     for (let i = 0; i < devices.count; ++i) {
                         const existingDevice = devices.get(i)
                         if (existingDevice.udid === udid) {
+                            if (!existingDevice.info.is_wireless && info.is_wireless) {
+                                console.log("Device is already connected via USB. Ignoring wireless connection event for:", udid)
+                                skipWirelessReplacement = true
+                                break
+                            }
                             devices.remove(i)
                             root.scheduleGc()
                             break
                         }
                     }
+                    if (skipWirelessReplacement)
+                        break
 
                     const pendingDeviceWasVisible =
                         root.currentDestination === "pendingDevice"

--- a/src/ui/IconLoader.qml
+++ b/src/ui/IconLoader.qml
@@ -1,9 +1,9 @@
 // SPDX-FileCopyrightText: 2025-2026 Uncore <https://github.com/uncor3>
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import QtQuick 2.15
-import QtQuick.Controls 2.15
-import QtQuick.Layouts 1.15
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
 import Qt5Compat.GraphicalEffects
 
 Rectangle {

--- a/src/ui/NetworkDevicesToConnect.qml
+++ b/src/ui/NetworkDevicesToConnect.qml
@@ -386,7 +386,7 @@ Item {
                                     id: pairingFileDialog
                                     title: qsTr("Choose pairing file")
                                     fileMode: FileDialog.OpenFile
-                                    nameFilters: ["*.plist"]
+                                    nameFilters: [qsTr("Property List files (*.plist)")]
                                     onAccepted: {
                                         var path = QmlUtils.url_to_path(selectedFile)
                                         if (!path || !address) return

--- a/src/ui/base/+windows/DefaultWindow.qml
+++ b/src/ui/base/+windows/DefaultWindow.qml
@@ -1,9 +1,9 @@
 // SPDX-FileCopyrightText: 2025-2026 Uncore <https://github.com/uncor3>
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import QtQuick 2.15
-import QtQuick.Controls 2.15
-import QtQuick.Layouts 1.15
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
 import ".." as App
 import FluentUI
 


### PR DESCRIPTION
Fixes #125

### Changes
- Updated  to prioritize active USB device connections ().
- Prevents incoming wireless discovery events () for the same device from overwriting the active USB connection state.
- Preserves access to USB-only tools (iFuse Mount, Cable Info, Wi-Fi enablement) when device is connected via USB cable while network discovery is active.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved connected-device handling to prevent wireless duplicates from replacing an already connected USB device.
  - Preserved replacement behavior for other duplicate-device events.
  - Improved connection tracking to distinguish wireless and USB connections.

- **User Experience**
  - Added a localized, descriptive file-type filter when selecting pairing files.

- **Maintenance**
  - Updated interface module imports for improved compatibility with the current Qt environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->